### PR TITLE
feat: Use arcgis instead of arcpy

### DIFF
--- a/src/palletjack/__init__.py
+++ b/src/palletjack/__init__.py
@@ -1,4 +1,4 @@
 """A library for updating AGOL feature services with data from SFTP sources
 """
 
-from .models import ColorRampReclassifier, FeatureServiceInLineUpdater, FeatureServiceOverwriter, SFTPLoader
+from .models import ColorRampReclassifier, FeatureServiceInlineUpdater, FeatureServiceOverwriter, SFTPLoader

--- a/src/palletjack/models.py
+++ b/src/palletjack/models.py
@@ -6,7 +6,6 @@ import logging
 from pathlib import Path
 
 import arcgis
-import arcpy
 import numpy as np
 import pandas as pd
 import pysftp
@@ -124,6 +123,12 @@ class FeatureServiceInlineUpdater:
             feature_service_url (str): URL to feature service
             fields (list): Names of fields to update
         """
+
+        #: Put this here to enable the package to install/run without arcpy installed if desired
+        try:
+            import arcpy  # pylint: disable=import-outside-toplevel
+        except ImportError as error:
+            raise ImportError('Failure importing arcpy. ArcGIS Pro must be installed.') from error
 
         self._class_logger.info('Updating `%s` in-place', feature_service_url)
         self._class_logger.debug('Updating fields %s', fields)

--- a/src/palletjack/models.py
+++ b/src/palletjack/models.py
@@ -287,10 +287,6 @@ class FeatureServiceInlineUpdater:
         number_of_rows_updated = self._parse_results(results, live_dataframe)
         return number_of_rows_updated
 
-        #: This does not work. Warum?
-        # updates_featurecollection = subset_dataframe.spatial.to_feature_collection()
-        # messages = feature_layer.append(upload_format='featureCollection', field_mappings=[{'name':'Count_', 'sourceName':'Count__y'}, {'name':'Amount', 'sourceName':'Amount_y'}, {'name':'Updated', 'sourceName':'Updated_y'}], edits=updates_featurecollection, upsert=True, update_geometry=False, rollback=True, return_messages=True)
-
 
 class FeatureServiceOverwriter:
     """Overwrites an AGOL Feature Service with data from a pandas DataFrame and a geometry source (Spatially-enabled

--- a/src/palletjack/models.py
+++ b/src/palletjack/models.py
@@ -210,9 +210,9 @@ class FeatureServiceInlineUpdater:
                   }
         """
         oid_and_key_lookup = {
-            row['objectId']: row[self.index_column] for _, row in live_dict.items() if row['objectId'] in object_ids
+            row['OBJECTID']: row[self.index_column] for _, row in live_dict.items() if row['OBJECTID'] in object_ids
         }
-        old_values_by_oid = {row['objectId']: row for _, row in live_dict.items() if row['objectId'] in object_ids}
+        old_values_by_oid = {row['OBJECTID']: row for _, row in live_dict.items() if row['OBJECTID'] in object_ids}
         new_data_as_dict_preserve_key = self.new_dataframe.set_index(self.index_column, drop=False).to_dict('index')
         new_values_by_oid = {
             object_id: new_data_as_dict_preserve_key[key] for object_id, key in oid_and_key_lookup.items()
@@ -282,7 +282,8 @@ class FeatureServiceInlineUpdater:
 
         self._class_logger.info('Updating itemid `%s` in-place', feature_layer_itemid)
         self._class_logger.debug('Updating fields %s', fields)
-        feature_layer = self.gis.content.get(feature_layer_itemid)
+        feature_layer_item = self.gis.content.get(feature_layer_itemid)
+        feature_layer = arcgis.features.FeatureLayer.fromitem(feature_layer_item)
         live_dataframe = pd.DataFrame.spatial.from_layer(feature_layer)
         subset_dataframe = self._get_common_rows(live_dataframe)
         if subset_dataframe.empty:

--- a/src/palletjack/models.py
+++ b/src/palletjack/models.py
@@ -295,7 +295,9 @@ class FeatureServiceInlineUpdater:
         results = feature_layer.edit_features(
             updates=cleaned_dataframe.spatial.to_featureset(), rollback_on_failure=True
         )
-        number_of_rows_updated = self._parse_results(results, live_dataframe)
+        log_fields = ['OBJECTID']
+        log_fields.extend(fields)
+        number_of_rows_updated = self._parse_results(results, live_dataframe[log_fields])
         return number_of_rows_updated
 
 

--- a/src/palletjack/models.py
+++ b/src/palletjack/models.py
@@ -197,7 +197,8 @@ class FeatureServiceInlineUpdater:
         """Create a dictionary of the old (existing, live) and new values based on a list of object ids
 
         Args:
-            live_dict (dict): The old (existing, live) data, key is an arbitrary index, content is another dict keyed by the field names.
+            live_dict (dict): The old (existing, live) data, key is an arbitrary index, content is another dict keyed
+            by the field names.
             object_ids (list[int]): The object ids to include in the new dictionary
 
         Returns:
@@ -230,7 +231,9 @@ class FeatureServiceInlineUpdater:
         """Integrate .edit() results with data for reporting purposes. Relies on _get_old_and_new_values().
 
         Args:
-            results_dict (dict): AGOL response as a python dict (raw output from .edit_features(). Defined in https://developers.arcgis.com/rest/services-reference/enterprise/apply-edits-feature-service-layer-.htm, where `true`/`false` are python True/False.
+            results_dict (dict): AGOL response as a python dict (raw output from .edit_features(). Defined in
+            https://developers.arcgis.com/rest/services-reference/enterprise/apply-edits-feature-service-layer-.htm,
+            where `true`/`false` are python True/False.
             live_dataframe (pd.DataFrame): Existing/live dataframe created from hosted feature layer.
 
         Returns:
@@ -265,7 +268,9 @@ class FeatureServiceInlineUpdater:
     def update_existing_features_in_hosted_feature_layer(self, feature_layer_itemid, fields) -> int:
         """Update existing features with new attribute data in the defined fields using arcgis instead of arcpy.
 
-        Relies on new data from self.new_dataframe. Uses the ArcGIS API for Python's .edit_features() method on a hosted feature layer item. May be fragile for large datasets, per .edit_features() documentation. Can't get .append() working properly.
+        Relies on new data from self.new_dataframe. Uses the ArcGIS API for Python's .edit_features() method on a
+        hosted feature layer item. May be fragile for large datasets, per .edit_features() documentation. Can't get
+        .append() working properly.
 
         Args:
             feature_layer_itemid (str): The AGOL item id of the hosted feature layer to update.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,18 +1,21 @@
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
+from arcgis.features import GeoAccessor, GeoSeriesAccessor
 from mock_arcpy import arcpy
+from pandas.api.types import CategoricalDtype
 
 import palletjack
 
 
 class TestFeatureServiceInLineUpdater:
 
-    def test_update_feature_service(self, mocker):
+    def test_update_existing_features_in_feature_service_with_arcpy(self, mocker):
         #: We create a mock that will be returned by UpdateCursor's mock's __enter__, thus becoming our context manager.
         #: We then set it's __iter__.return_value to define the data we want it to iterate over.
         cursor_mock = mocker.MagicMock()
@@ -27,12 +30,408 @@ class TestFeatureServiceInLineUpdater:
         fsupdater_mock = mocker.Mock()
         fsupdater_mock.data_as_dict = {'12345': {'Count': '57', 'Amount': 100.00, 'Date': '1/1/2022'}}
 
-        palletjack.FeatureServiceInLineUpdater.update_feature_service(
+        palletjack.FeatureServiceInLineUpdater.update_existing_features_in_feature_service_with_arcpy(
             fsupdater_mock, 'foo', ['ZipCode', 'Count', 'Amount', 'Date']
         )
 
         cursor_mock.updateRow.assert_called_with(['12345', '57', 100.00, '1/1/2022'])
         cursor_mock.updateRow.assert_called_once()
+
+    def test_clean_dataframe_columns_renames_and_drops_columns(self, mocker):
+        class_mock = mocker.Mock()
+        fields = ['foo', 'bar']
+        dataframe = pd.DataFrame(columns=['foo_x', 'bar_x', 'baz', 'foo_y', 'bar_y'])
+
+        renamed = palletjack.FeatureServiceInLineUpdater._clean_dataframe_columns(class_mock, dataframe, fields)
+
+        assert list(renamed.columns) == ['baz', 'foo', 'bar']
+
+    def test_clean_dataframe_columns_handles_field_not_found_in_dataframe(self, mocker):
+        class_mock = mocker.Mock()
+        fields = ['foo', 'bar', 'buz']
+        dataframe = pd.DataFrame(columns=['foo_x', 'bar_x', 'baz', 'foo_y', 'bar_y'])
+
+        renamed = palletjack.FeatureServiceInLineUpdater._clean_dataframe_columns(class_mock, dataframe, fields)
+
+        assert list(renamed.columns) == ['baz', 'foo', 'bar']
+
+    def test_clean_dataframe_columns_deletes_merge_field(self, mocker):
+        class_mock = mocker.Mock()
+        fields = ['foo', 'bar', 'buz']
+        dataframe = pd.DataFrame(columns=['foo_x', 'bar_x', 'baz', 'foo_y', 'bar_y', '_merge'])
+
+        renamed = palletjack.FeatureServiceInLineUpdater._clean_dataframe_columns(class_mock, dataframe, fields)
+
+        assert list(renamed.columns) == ['baz', 'foo', 'bar']
+
+    def test_get_common_rows_joins_properly_all_rows_in_both(self, mocker):
+        class_mock = mocker.Mock()
+        class_mock.index_column = 'key'
+        class_mock.new_dataframe = pd.DataFrame({'col1': [10, 20, 30], 'col2': [40, 50, 60], 'key': ['a', 'b', 'c']})
+        live_dataframe = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6], 'key': ['a', 'b', 'c']})
+
+        joined = palletjack.FeatureServiceInLineUpdater._get_common_rows(class_mock, live_dataframe)
+
+        merge_type = CategoricalDtype(categories=['left_only', 'right_only', 'both'], ordered=False)
+        expected = pd.DataFrame({
+            'col1_x': [1, 2, 3],
+            'col2_x': [4, 5, 6],
+            'key': ['a', 'b', 'c'],
+            'col1_y': [10, 20, 30],
+            'col2_y': [40, 50, 60],
+            '_merge': ['both', 'both', 'both']
+        })
+        expected['_merge'] = expected['_merge'].astype(merge_type)
+
+        pd.testing.assert_frame_equal(joined, expected)
+
+    def test_get_common_rows_subsets_properly_new_has_fewer_rows(self, mocker):
+
+        class_mock = mocker.Mock()
+        class_mock.index_column = 'key'
+        class_mock.new_dataframe = pd.DataFrame({'col1': [20, 30], 'col2': [50, 60], 'key': ['b', 'c']})
+        live_dataframe = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6], 'key': ['a', 'b', 'c']})
+
+        joined = palletjack.FeatureServiceInLineUpdater._get_common_rows(class_mock, live_dataframe)
+
+        merge_type = CategoricalDtype(categories=['left_only', 'right_only', 'both'], ordered=False)
+        expected = pd.DataFrame({
+            'col1_x': [2, 3],
+            'col2_x': [5, 6],
+            'key': ['b', 'c'],
+            'col1_y': [20, 30],
+            'col2_y': [50, 60],
+            '_merge': ['both', 'both']
+        },
+                                index=[1, 2])
+        expected['_merge'] = expected['_merge'].astype(merge_type)
+
+        pd.testing.assert_frame_equal(joined, expected, check_dtype=False)
+
+    def test_get_common_rows_logs_warning_for_rows_not_in_existing_dataset(self, mocker, caplog):
+
+        class_mock = mocker.Mock()
+        class_mock.index_column = 'key'
+        class_mock.new_dataframe = pd.DataFrame({
+            'col1': [10, 20, 30, 80],
+            'col2': [40, 50, 60, 70],
+            'key': ['a', 'b', 'c', 'd']
+        })
+        class_mock._class_logger = logging.getLogger('root')
+        live_dataframe = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6], 'key': ['a', 'b', 'c']})
+
+        joined = palletjack.FeatureServiceInLineUpdater._get_common_rows(class_mock, live_dataframe)
+
+        merge_type = CategoricalDtype(categories=['left_only', 'right_only', 'both'], ordered=False)
+        expected = pd.DataFrame({
+            'col1_x': [1, 2, 3],
+            'col2_x': [4, 5, 6],
+            'key': ['a', 'b', 'c'],
+            'col1_y': [10, 20, 30],
+            'col2_y': [40, 50, 60],
+            '_merge': ['both', 'both', 'both']
+        },
+                                index=[0, 1, 2])
+        expected['_merge'] = expected['_merge'].astype(merge_type)
+
+        pd.testing.assert_frame_equal(joined, expected, check_dtype=False)
+        assert 'The following keys from the new data were not found in the existing dataset: [\'d\']' in caplog.text
+
+    def test_parse_results_returns_correct_number_of_updated_rows(self, mocker):
+        class_mock = mocker.Mock()
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': True
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(class_mock, results_dict, live_dataframe)
+
+        assert rows_updated == 2
+
+    def test_parse_results_retuns_0_if_both_successful_and_failed_result(self, mocker):
+        class_mock = mocker.Mock()
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': False
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(class_mock, results_dict, live_dataframe)
+
+        assert rows_updated == 0
+
+    def test_parse_results_logs_success_info(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': True
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.INFO):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert '2 rows successfully updated' in caplog.text
+            assert "{'objectId': 1, 'data': 'foo'}" not in caplog.text
+            assert "{'objectId': 2, 'data': 'bar'}" not in caplog.text
+
+    def test_parse_results_logs_success_debug(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': True
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.DEBUG):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert '2 rows successfully updated' in caplog.text
+            assert "{'objectId': 1, 'data': 'foo'}" in caplog.text
+            assert "{'objectId': 2, 'data': 'bar'}" in caplog.text
+
+    def test_parse_results_logs_failures_at_warning(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': False
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.WARNING):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert caplog.records[
+                0
+            ].message == 'The following 1 updates failed. As a result, all successfull updates should have been rolled back.' and caplog.records[
+                0].levelname == 'WARNING'
+            assert caplog.records[1].message == "{'objectId': 2, 'data': 'bar'}" and caplog.records[
+                1].levelname == 'WARNING'
+
+    def test_parse_results_doesnt_log_any_success_on_all_failed(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': False
+                },
+                {
+                    'objectId': 2,
+                    'success': False
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.INFO):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert 'rows successfully updated' not in caplog.text
+
+    def test_parse_results_logs_successes_before_failure(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [
+                {
+                    'objectId': 1,
+                    'success': True
+                },
+                {
+                    'objectId': 2,
+                    'success': False
+                },
+            ],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.DEBUG):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+            assert caplog.records[0].message == '1 rows successfully updated' and caplog.records[0].levelname == 'INFO'
+            assert caplog.records[2].message == "{'objectId': 1, 'data': 'foo'}" and caplog.records[
+                2].levelname == 'DEBUG'
+            assert caplog.records[
+                3
+            ].message == 'The following 1 updates failed. As a result, all successfull updates should have been rolled back.' and caplog.records[
+                3].levelname == 'WARNING'
+            assert caplog.records[4].message == "{'objectId': 2, 'data': 'bar'}" and caplog.records[
+                4].levelname == 'WARNING'
+
+    def test_parse_results_returns_0_when_results_are_empty(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        results_dict = {
+            'addResults': [],
+            'updateResults': [],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.INFO):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert rows_updated == 0
+
+    def test_parse_results_logs_appropriately_when_results_are_empty(self, mocker, caplog):
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        results_dict = {
+            'addResults': [],
+            'updateResults': [],
+            'deleteResults': [],
+        }
+        live_dataframe = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+        })
+
+        with caplog.at_level(logging.INFO):
+            rows_updated = palletjack.FeatureServiceInLineUpdater._parse_results(
+                class_mock, results_dict, live_dataframe
+            )
+
+            assert 'No update results returned; no updates attempted' in caplog.text
+            assert 'rows successfully updated' not in caplog.text
+            assert 'updates failed.' not in caplog.text
+
+    def test_update_existing_features_in_hosted_feature_layer_no_matching_rows_returns_0(self, mocker, caplog):
+        pd_mock = mocker.Mock()
+        pd_mock.return_value = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+            'key': ['a', 'b'],
+        })
+        mocker.patch.object(pd.DataFrame.spatial, 'from_layer', new=pd_mock)
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        class_mock.new_dataframe = pd.DataFrame({
+            'data': ['FOO', 'BAR'],
+            'key': ['c', 'd'],
+        })
+        class_mock.index_column = 'key'
+
+        updated_rows = palletjack.FeatureServiceInLineUpdater.update_existing_features_in_hosted_feature_layer(
+            class_mock, '1234', ['data', 'key']
+        )
+
+        assert updated_rows == 0
+
+    def test_update_existing_features_in_hosted_feature_layer_no_matching_rows_properly_logs(self, mocker, caplog):
+        pd_mock = mocker.Mock()
+        pd_mock.return_value = pd.DataFrame({
+            'objectId': [1, 2],
+            'data': ['foo', 'bar'],
+            'key': ['a', 'b'],
+        })
+        mocker.patch.object(pd.DataFrame.spatial, 'from_layer', new=pd_mock)
+        class_mock = mocker.Mock()
+        class_mock._class_logger = logging.getLogger('root')
+        class_mock.new_dataframe = pd.DataFrame({
+            'data': ['FOO', 'BAR'],
+            'key': ['c', 'd'],
+        })
+        class_mock.index_column = 'key'
+
+        updated_rows = palletjack.FeatureServiceInLineUpdater.update_existing_features_in_hosted_feature_layer(
+            class_mock, '1234', ['data', 'key']
+        )
+
+        assert 'No matching rows between live dataset and new dataset based on field `key`' in caplog.text
 
 
 class TestSFTPLoader:
@@ -200,7 +599,7 @@ class TestColorRampReclassifier:
 
         assert stops == [100, 279, 458, 637, 816]
 
-    def test_calculate_new_stops_mistmached_column_raises_error(self):
+    def test_calculate_new_stops_mismatched_column_raises_error(self):
         dataframe = pd.DataFrame({'numbers': [100, 300, 500, 700, 900]})
 
         with pytest.raises(ValueError) as error_info:


### PR DESCRIPTION
This code uses the `arcgis` module for doing in-line updates of existing attribute data instead of using `arcpy`'s cursors. This should enable it to be used in any environment, not just those that have ArcGIS Pro installed. 

This relies on the [`FeatureLayer.edit_features()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html#arcgis.features.FeatureLayer.append) method to perform the edits. The [`FeatureLayer.append()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html#arcgis.features.FeatureLayer.append) method seems like it would be faster, but I haven't been able to figure out a way to pass info from a dataframe to `.append()`. Performance does not seem to be an issue with my testing dataset with ~200 features.

Due to changes in the function names, this should probably bump the major version to 2.0.0.