### PR TITLE
Load data from Google Sheets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,10 @@ setup(
     keywords=['gis'],
     install_requires=[
         'pysftp==0.2.9',
-        'pandas==1.3.3',
+        'pandas==1.3.*',
         'numpy==1.21.*',
         'arcgis==1.9.*',
+        'pygsheets==2.0.*',
     ],
     extras_require={
         'tests': [

--- a/src/palletjack/__init__.py
+++ b/src/palletjack/__init__.py
@@ -1,4 +1,5 @@
 """A library for updating AGOL feature services with data from SFTP sources
 """
 
-from .models import ColorRampReclassifier, FeatureServiceInlineUpdater, FeatureServiceOverwriter, SFTPLoader
+from .loaders import GSheetLoader, SFTPLoader
+from .updaters import ColorRampReclassifier, FeatureServiceInlineUpdater, FeatureServiceOverwriter

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -55,8 +55,7 @@ class GSheetLoader:
 
         return worksheet_dfs
 
-    @staticmethod
-    def combine_worksheets_into_single_dataframe(worksheet_dfs):
+    def combine_worksheets_into_single_dataframe(self, worksheet_dfs):
         """Merge worksheet dataframes (having same columns) into a single dataframe with a new 'worksheet' column
         identifying the source worksheet.
 
@@ -78,6 +77,7 @@ class GSheetLoader:
         if not all([set(dataframes[0].columns) == set(df.columns) for df in dataframes]):
             raise ValueError('Columns do not match; cannot create mutli-index dataframe')
 
+        self._class_logger.debug('Concatting worksheet dataframes %s into a single dataframe', worksheet_dfs.keys())
         concatted_df = pd.concat(dataframes, keys=worksheet_dfs.keys(), names=['worksheet', 'row'])
         return concatted_df.reset_index(level='worksheet')
 

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -1,16 +1,32 @@
+"""Classes for loading data from various sources into a pandas dataframe
+"""
+
 import logging
+from pathlib import Path
 
 import pandas as pd
 import pygsheets
+import pysftp
 
 
 class GSheetLoader:
+    """Loads data from a Google Sheets spreadsheet into a pandas data frame"""
 
     def __init__(self, service_file):
         self.gsheets_client = pygsheets.authorize(service_file=service_file)
         self._class_logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
     def load_specific_worksheet_into_dataframe(self, sheet_id, worksheet, by_title=False):
+        """Load a single worksheet from a spreadsheet into a dataframe by worksheet index or title
+
+        Args:
+            sheet_id (str): The ID of the sheet (long alpha-numeric unique ID)
+            worksheet (int or str): Zero-based index of the worksheet or the worksheet title
+            by_title (bool, optional): Search for worksheet by title instead of index. Defaults to False.
+
+        Returns:
+            pd.DataFrame: The specified worksheet as a data frame.
+        """
 
         self._class_logger.debug('Loading sheet ID %s', sheet_id)
         sheet = self.gsheets_client.open_by_key(sheet_id)
@@ -23,6 +39,15 @@ class GSheetLoader:
             return sheet.worksheet(worksheet).get_as_df()
 
     def load_all_worksheets_into_dataframes(self, sheet_id):
+        """Load all worksheets into a dictionary of dataframes. Keys are the worksheet.
+
+        Args:
+            sheet_id (str): The ID of the sheet (long alpha-numeric unique ID)
+
+        Returns:
+            dict: {'worksheet_name': Worksheet as a dataframe}
+        """
+
         self._class_logger.debug('Loading sheet ID %s', sheet_id)
         sheet = self.gsheets_client.open_by_key(sheet_id)
 
@@ -32,6 +57,21 @@ class GSheetLoader:
 
     @staticmethod
     def combine_worksheets_into_single_dataframe(worksheet_dfs):
+        """Merge worksheet dataframes (having same columns) into a single dataframe with a new 'worksheet' column
+        identifying the source worksheet.
+
+        Args:
+            worksheet_dfs (dict): {'worksheet_name': Worksheet as a dataframe}.
+
+        Raises:
+            ValueError: If all the worksheets in worksheets_dfs don't have the same column index, it raises an error
+            and bombs out.
+
+        Returns:
+            pd.DataFrame: A single combined data frame with a new 'worksheet' column identifying the worksheet the row
+            came from. The row index is the original row numbers and is probably not unique.
+        """
+
         dataframes = list(worksheet_dfs.values())
 
         #: Make sure all the dataframes have the same columns
@@ -40,3 +80,94 @@ class GSheetLoader:
 
         concatted_df = pd.concat(dataframes, keys=worksheet_dfs.keys(), names=['worksheet', 'row'])
         return concatted_df.reset_index(level='worksheet')
+
+
+class SFTPLoader:
+    """Loads data from an SFTP share into a pandas DataFrame
+    """
+
+    def __init__(self, host, username, password, knownhosts_file, download_dir):
+        self.host = host
+        self.username = username
+        self.password = password
+        self.knownhosts_file = knownhosts_file
+        self.download_dir = download_dir
+        self._class_logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+
+    def download_sftp_folder_contents(self, sftp_folder='upload'):
+        """Download all files in sftp_folder to the SFTPLoader's download_dir
+
+        Args:
+            sftp_folder (str, optional): Path of remote folder, relative to sftp home directory. Defaults to 'upload'.
+        """
+
+        self._class_logger.info('Downloading files from `%s:%s` to `%s`', self.host, sftp_folder, self.download_dir)
+        starting_file_count = len(list(self.download_dir.iterdir()))
+        self._class_logger.debug('SFTP Username: %s', self.username)
+        connection_opts = pysftp.CnOpts(knownhosts=self.knownhosts_file)
+        with pysftp.Connection(
+            self.host, username=self.username, password=self.password, cnopts=connection_opts
+        ) as sftp:
+            try:
+                sftp.get_d(sftp_folder, self.download_dir, preserve_mtime=True)
+            except FileNotFoundError as error:
+                raise FileNotFoundError(f'Folder `{sftp_folder}` not found on SFTP server') from error
+        downloaded_file_count = len(list(self.download_dir.iterdir())) - starting_file_count
+        if not downloaded_file_count:
+            raise ValueError('No files downloaded')
+        return downloaded_file_count
+
+    def download_sftp_single_file(self, filename, sftp_folder='upload'):
+        """Download filename into SFTPLoader's download_dir
+
+        Args:
+            filename (str): Filename to download; used as output filename as well.
+            sftp_folder (str, optional): Path of remote folder, relative to sftp home directory. Defaults to 'upload'.
+
+        Raises:
+            FileNotFoundError: Will warn if pysftp can't find the file or folder on the sftp server
+
+        Returns:
+            Path: Downloaded file's path
+        """
+
+        outfile = Path(self.download_dir, filename)
+
+        self._class_logger.info('Downloading %s from `%s:%s` to `%s`', filename, self.host, sftp_folder, outfile)
+        self._class_logger.debug('SFTP Username: %s', self.username)
+        connection_opts = pysftp.CnOpts(knownhosts=self.knownhosts_file)
+        try:
+            with pysftp.Connection(
+                self.host,
+                username=self.username,
+                password=self.password,
+                cnopts=connection_opts,
+                default_path=sftp_folder,
+            ) as sftp:
+                sftp.get(filename, localpath=outfile, preserve_mtime=True)
+        except FileNotFoundError as error:
+            raise FileNotFoundError(f'File `{filename}` or folder `{sftp_folder}`` not found on SFTP server') from error
+
+        return outfile
+
+    def read_csv_into_dataframe(self, filename, column_types=None):
+        """Read filename into a dataframe with optional column names and types
+
+        Args:
+            filename (str): Name of file in the SFTPLoader's download_dir
+            column_types (dict, optional): Column names and their dtypes(np.float64, str, etc). Defaults to None.
+
+        Returns:
+            pd.DataFrame: CSV as a pandas dataframe
+        """
+
+        self._class_logger.info('Reading `%s` into dataframe', filename)
+        filepath = Path(self.download_dir, filename)
+        column_names = None
+        if column_types:
+            column_names = list(column_types.keys())
+        dataframe = pd.read_csv(filepath, names=column_names, dtype=column_types)
+        self._class_logger.debug('Dataframe shape: %s', dataframe.shape)
+        if len(dataframe.index) == 0:
+            self._class_logger.warning('Dataframe contains no rows. Shape: %s', dataframe.shape)
+        return dataframe

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -1,0 +1,42 @@
+import logging
+
+import pandas as pd
+import pygsheets
+
+
+class GSheetLoader:
+
+    def __init__(self, service_file):
+        self.gsheets_client = pygsheets.authorize(service_file=service_file)
+        self._class_logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+
+    def load_specific_worksheet_into_dataframe(self, sheet_id, worksheet, by_title=False):
+
+        self._class_logger.debug('Loading sheet ID %s', sheet_id)
+        sheet = self.gsheets_client.open_by_key(sheet_id)
+
+        if by_title:
+            self._class_logger.debug('Loading worksheet by title %s', worksheet)
+            return sheet.worksheet_by_title(worksheet).get_as_df()
+        else:
+            self._class_logger.debug('Loading worksheet by index %s', worksheet)
+            return sheet.worksheet(worksheet).get_as_df()
+
+    def load_all_worksheets_into_dataframes(self, sheet_id):
+        self._class_logger.debug('Loading sheet ID %s', sheet_id)
+        sheet = self.gsheets_client.open_by_key(sheet_id)
+
+        worksheet_dfs = {worksheet.title: worksheet.get_as_df() for worksheet in sheet.worksheets()}
+
+        return worksheet_dfs
+
+    @staticmethod
+    def combine_worksheets_into_single_dataframe(worksheet_dfs):
+        dataframes = list(worksheet_dfs.values())
+
+        #: Make sure all the dataframes have the same columns
+        if not all([set(dataframes[0].columns) == set(df.columns) for df in dataframes]):
+            raise ValueError('Columns do not match; cannot create mutli-index dataframe')
+
+        concatted_df = pd.concat(dataframes, keys=worksheet_dfs.keys(), names=['worksheet', 'row'])
+        return concatted_df.reset_index(level='worksheet')

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pygsheets
 import pysftp
 
+logger = logging.getLogger(__name__)
+
 
 class GSheetLoader:
     """Loads data from a Google Sheets spreadsheet into a pandas data frame"""

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas import testing as tm
 
-from palletjack import loaders
+import palletjack
 
 
 class TestGSheetsLoader:
@@ -19,7 +19,7 @@ class TestGSheetsLoader:
         gsheet_loader_mock = mocker.Mock()
         gsheet_loader_mock.gsheets_client = client_mock
 
-        loaders.GSheetLoader.load_specific_worksheet_into_dataframe(gsheet_loader_mock, 'foobar', 5)
+        palletjack.GSheetLoader.load_specific_worksheet_into_dataframe(gsheet_loader_mock, 'foobar', 5)
 
         sheet_mock.worksheet.assert_called_once_with(5)
         sheet_mock.worksheet_by_title.assert_not_called()
@@ -33,7 +33,9 @@ class TestGSheetsLoader:
         gsheet_loader_mock = mocker.Mock()
         gsheet_loader_mock.gsheets_client = client_mock
 
-        loaders.GSheetLoader.load_specific_worksheet_into_dataframe(gsheet_loader_mock, 'foobar', '2015', by_title=True)
+        palletjack.GSheetLoader.load_specific_worksheet_into_dataframe(
+            gsheet_loader_mock, 'foobar', '2015', by_title=True
+        )
 
         sheet_mock.worksheet.assert_not_called
         sheet_mock.worksheet_by_title.assert_called_once_with('2015')
@@ -52,7 +54,7 @@ class TestGSheetsLoader:
         gsheet_loader_mock = mocker.Mock()
         gsheet_loader_mock.gsheets_client = client_mock
 
-        df_dict = loaders.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
+        df_dict = palletjack.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
 
         test_dict = {'ws1': 'df1'}
 
@@ -76,7 +78,7 @@ class TestGSheetsLoader:
         gsheet_loader_mock = mocker.Mock()
         gsheet_loader_mock.gsheets_client = client_mock
 
-        df_dict = loaders.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
+        df_dict = palletjack.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
 
         test_dict = {'ws1': 'df1', 'ws2': 'df2'}
 
@@ -95,7 +97,7 @@ class TestGSheetsLoader:
 
         df_dict = {'df1': df1, 'df2': df2}
 
-        combined_df = loaders.GSheetLoader.combine_worksheets_into_single_dataframe(df_dict)
+        combined_df = palletjack.GSheetLoader.combine_worksheets_into_single_dataframe(mocker.Mock(), df_dict)
 
         test_df = pd.DataFrame({
             'worksheet': ['df1', 'df1', 'df2', 'df2'],
@@ -120,10 +122,8 @@ class TestGSheetsLoader:
 
         df_dict = {'df1': df1, 'df2': df2}
 
-        with pytest.raises(ValueError) as error:
-            combined_df = loaders.GSheetLoader.combine_worksheets_into_single_dataframe(df_dict)
-
-        assert 'Columns do not match; cannot create mutli-index dataframe' in str(error.value)
+        with pytest.raises(ValueError, match='Columns do not match; cannot create mutli-index dataframe'):
+            combined_df = palletjack.GSheetLoader.combine_worksheets_into_single_dataframe(mocker.Mock(), df_dict)
 
 
 class TestSFTPLoader:
@@ -147,7 +147,7 @@ class TestSFTPLoader:
         cnopts_mock.side_effect = lambda knownhosts: knownhosts
         mocker.patch('pysftp.CnOpts', new=cnopts_mock)
 
-        loaders.SFTPLoader.download_sftp_folder_contents(sftploader_mock)
+        palletjack.SFTPLoader.download_sftp_folder_contents(sftploader_mock)
 
         context_manager_mock.assert_called_with(
             'sftp_host', username='username', password='password', cnopts='knownhosts_file'
@@ -170,7 +170,7 @@ class TestSFTPLoader:
         cnopts_mock.side_effect = lambda knownhosts: knownhosts
         mocker.patch('pysftp.CnOpts', new=cnopts_mock)
 
-        loaders.SFTPLoader.download_sftp_single_file(sftploader_mock, 'filename', 'upload')
+        palletjack.SFTPLoader.download_sftp_single_file(sftploader_mock, 'filename', 'upload')
 
         context_manager_mock.assert_called_with(
             'sftp_host', username='username', password='password', cnopts='knownhosts_file', default_path='upload'
@@ -186,7 +186,7 @@ class TestSFTPLoader:
 
         column_types = {'bar': np.float64}
 
-        loaders.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz', column_types)
+        palletjack.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz', column_types)
 
         pd_mock.assert_called_with(Path('foo', 'baz'), names=['bar'], dtype=column_types)
 
@@ -198,6 +198,6 @@ class TestSFTPLoader:
         sftploader_mock = mocker.Mock()
         sftploader_mock.download_dir = 'foo'
 
-        loaders.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz')
+        palletjack.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz')
 
         pd_mock.assert_called_with(Path('foo', 'baz'), names=None, dtype=None)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,125 @@
+from http import client
+
+import pandas as pd
+import pytest
+from pandas import testing as tm
+
+from palletjack import loaders
+
+
+class TestGSheetsLoader:
+
+    def test_load_specific_worksheet_into_dataframe_by_id(self, mocker):
+        sheet_mock = mocker.Mock()
+
+        client_mock = mocker.Mock()
+        client_mock.open_by_key.return_value = sheet_mock
+
+        gsheet_loader_mock = mocker.Mock()
+        gsheet_loader_mock.gsheets_client = client_mock
+
+        loaders.GSheetLoader.load_specific_worksheet_into_dataframe(gsheet_loader_mock, 'foobar', 5)
+
+        sheet_mock.worksheet.assert_called_once_with(5)
+        sheet_mock.worksheet_by_title.assert_not_called()
+
+    def test_load_specific_worksheet_into_dataframe_by_title(self, mocker):
+        sheet_mock = mocker.Mock()
+
+        client_mock = mocker.Mock()
+        client_mock.open_by_key.return_value = sheet_mock
+
+        gsheet_loader_mock = mocker.Mock()
+        gsheet_loader_mock.gsheets_client = client_mock
+
+        loaders.GSheetLoader.load_specific_worksheet_into_dataframe(gsheet_loader_mock, 'foobar', '2015', by_title=True)
+
+        sheet_mock.worksheet.assert_not_called
+        sheet_mock.worksheet_by_title.assert_called_once_with('2015')
+
+    def test_load_all_worksheets_into_dataframes_single_worksheet(self, mocker):
+        worksheet_mock = mocker.Mock()
+        worksheet_mock.title = 'ws1'
+        worksheet_mock.get_as_df.return_value = 'df1'
+
+        sheet_mock = mocker.Mock()
+        sheet_mock.worksheets.return_value = [worksheet_mock]
+
+        client_mock = mocker.Mock()
+        client_mock.open_by_key.return_value = sheet_mock
+
+        gsheet_loader_mock = mocker.Mock()
+        gsheet_loader_mock.gsheets_client = client_mock
+
+        df_dict = loaders.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
+
+        test_dict = {'ws1': 'df1'}
+
+        assert df_dict == test_dict
+
+    def test_load_all_worksheets_into_dataframes_multiple_worksheets(self, mocker):
+        ws1_mock = mocker.Mock()
+        ws1_mock.title = 'ws1'
+        ws1_mock.get_as_df.return_value = 'df1'
+
+        ws2_mock = mocker.Mock()
+        ws2_mock.title = 'ws2'
+        ws2_mock.get_as_df.return_value = 'df2'
+
+        sheet_mock = mocker.Mock()
+        sheet_mock.worksheets.return_value = [ws1_mock, ws2_mock]
+
+        client_mock = mocker.Mock()
+        client_mock.open_by_key.return_value = sheet_mock
+
+        gsheet_loader_mock = mocker.Mock()
+        gsheet_loader_mock.gsheets_client = client_mock
+
+        df_dict = loaders.GSheetLoader.load_all_worksheets_into_dataframes(gsheet_loader_mock, 'foobar')
+
+        test_dict = {'ws1': 'df1', 'ws2': 'df2'}
+
+        assert df_dict == test_dict
+
+    def test_combine_worksheets_into_single_dataframe_combines_properly(self, mocker):
+        df1 = pd.DataFrame({
+            'foo': [1, 2],
+            'bar': [3, 4],
+        })
+
+        df2 = pd.DataFrame({
+            'foo': [10, 11],
+            'bar': [12, 13],
+        })
+
+        df_dict = {'df1': df1, 'df2': df2}
+
+        combined_df = loaders.GSheetLoader.combine_worksheets_into_single_dataframe(df_dict)
+
+        test_df = pd.DataFrame({
+            'worksheet': ['df1', 'df1', 'df2', 'df2'],
+            'foo': [1, 2, 10, 11],
+            'bar': [3, 4, 12, 13],
+        })
+        test_df.index = [0, 1, 0, 1]
+        test_df.index.name = 'row'
+
+        tm.assert_frame_equal(combined_df, test_df)
+
+    def test_combine_worksheets_into_single_dataframe_raises_error_on_mismatched_columns(self, mocker):
+        df1 = pd.DataFrame({
+            'foo': [1, 2],
+            'bar': [3, 4],
+        })
+
+        df2 = pd.DataFrame({
+            'foo': [10, 11],
+            'baz': [12, 13],
+        })
+
+        df_dict = {'df1': df1, 'df2': df2}
+
+        with pytest.raises(ValueError) as error:
+            combined_df = loaders.GSheetLoader.combine_worksheets_into_single_dataframe(df_dict)
+
+        assert 'Columns do not match; cannot create mutli-index dataframe' in str(error.value)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,6 @@
-from http import client
+from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 from pandas import testing as tm
@@ -123,3 +124,80 @@ class TestGSheetsLoader:
             combined_df = loaders.GSheetLoader.combine_worksheets_into_single_dataframe(df_dict)
 
         assert 'Columns do not match; cannot create mutli-index dataframe' in str(error.value)
+
+
+class TestSFTPLoader:
+
+    def test_download_sftp_folder_contents_uses_right_credentials(self, mocker):
+        sftploader_mock = mocker.Mock()
+        sftploader_mock.knownhosts_file = 'knownhosts_file'
+        sftploader_mock.host = 'sftp_host'
+        sftploader_mock.username = 'username'
+        sftploader_mock.password = 'password'
+        download_dir_mock = mocker.Mock()
+        download_dir_mock.iterdir.side_effect = [[], ['file_a', 'file_b']]
+        sftploader_mock.download_dir = download_dir_mock
+
+        connection_mock = mocker.MagicMock()
+        context_manager_mock = mocker.MagicMock()
+        context_manager_mock.return_value.__enter__.return_value = connection_mock
+        mocker.patch('pysftp.Connection', new=context_manager_mock)
+
+        cnopts_mock = mocker.Mock()
+        cnopts_mock.side_effect = lambda knownhosts: knownhosts
+        mocker.patch('pysftp.CnOpts', new=cnopts_mock)
+
+        loaders.SFTPLoader.download_sftp_folder_contents(sftploader_mock)
+
+        context_manager_mock.assert_called_with(
+            'sftp_host', username='username', password='password', cnopts='knownhosts_file'
+        )
+
+    def test_download_sftp_single_file_uses_right_credentials(self, mocker):
+        sftploader_mock = mocker.Mock()
+        sftploader_mock.knownhosts_file = 'knownhosts_file'
+        sftploader_mock.host = 'sftp_host'
+        sftploader_mock.username = 'username'
+        sftploader_mock.password = 'password'
+        sftploader_mock.download_dir = 'download_dir'
+
+        connection_mock = mocker.MagicMock()
+        context_manager_mock = mocker.MagicMock()
+        context_manager_mock.return_value.__enter__.return_value = connection_mock
+        mocker.patch('pysftp.Connection', new=context_manager_mock)
+
+        cnopts_mock = mocker.Mock()
+        cnopts_mock.side_effect = lambda knownhosts: knownhosts
+        mocker.patch('pysftp.CnOpts', new=cnopts_mock)
+
+        loaders.SFTPLoader.download_sftp_single_file(sftploader_mock, 'filename', 'upload')
+
+        context_manager_mock.assert_called_with(
+            'sftp_host', username='username', password='password', cnopts='knownhosts_file', default_path='upload'
+        )
+
+    def test_read_csv_into_dataframe_with_column_names(self, mocker):
+        pd_mock = mocker.Mock()
+        pd_mock.return_value = pd.DataFrame()
+        mocker.patch.object(pd, 'read_csv', new=pd_mock)
+
+        sftploader_mock = mocker.Mock()
+        sftploader_mock.download_dir = 'foo'
+
+        column_types = {'bar': np.float64}
+
+        loaders.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz', column_types)
+
+        pd_mock.assert_called_with(Path('foo', 'baz'), names=['bar'], dtype=column_types)
+
+    def test_read_csv_into_dataframe_no_column_names(self, mocker):
+        pd_mock = mocker.Mock()
+        pd_mock.return_value = pd.DataFrame()
+        mocker.patch.object(pd, 'read_csv', new=pd_mock)
+
+        sftploader_mock = mocker.Mock()
+        sftploader_mock.download_dir = 'foo'
+
+        loaders.SFTPLoader.read_csv_into_dataframe(sftploader_mock, 'baz')
+
+        pd_mock.assert_called_with(Path('foo', 'baz'), names=None, dtype=None)


### PR DESCRIPTION
Adds a loader to import a google spreadsheet as a dict of dataframes of each worksheet or a single, merged dataframe of all worksheets (if possible). Internal submodule organization, but the external API isn't changed thanks to imports in `__init__.py`.