### PR TITLE
Improvements and fixes to attachment downloading from Google Drive/updating AGOL attachments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,8 +59,10 @@ The initializer sets the output directory for saving the files. The `out_dir` at
 
 Methods
 
-- `download_image_from_google_drive(self, sharing_link)`
-  - Download a file to the out_dir set on the instantiated object. `sharing_link` should be in the form `https://drive.google.com/file/d/big_long_id/etc`. Will raise an error if the URL doesn't match this pattern or it can't extract the unique id from the sharing URL. Will also raise an error if the header's Content-Type is text/html, which usually indicates the HTTP response was an error message instead of the file.
+- `download_file_from_google_drive(self, sharing_link, join_id)`
+  - Download a file to the out_dir set on the instantiated object. `sharing_link` should be in the form `https://drive.google.com/file/d/big_long_id/etc`. `join_id` is used for logging purposes to identify which attachment is being worked on. Will log an error if the URL doesn't match this pattern or it can't extract the unique id from the sharing URL. Will also log an error if the header's Content-Type is text/html, which usually indicates the HTTP response was an error message instead of the file.
+- `download_attachments_from_dataframe(self, dataframe, sharing_link_column, join_id_column, output_path_column)`
+  - Calls `download_file_from_google_drive` for every row in `dataframe`, saving the full path of the resulting file in `output_path_column`
 
 ## Updaters
 

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -31,27 +31,14 @@ def load_google_sheet_then_download_and_update_attachments():
 
     #: Use a GoogleDriveDownloader to download all the pictures from a single worksheet dataframe
     uorg_2021_dataframe = worksheets['2021']
-    pics_list = list(uorg_2021_dataframe[attachment_column])
-
     downloader = GoogleDriveDownloader(out_dir)
-    for pic_link in pics_list:
-        #: if the link is an empty string or null, notify the user and don't try to download
-        if not pic_link:
-            print('No URL in attachment column')
-            continue
-        #: Skids are responsible for handling errors. In this case, if it can't access the link, print out the error
-        try:
-            downloader.download_image_from_google_drive(pic_link)
-        except RuntimeError as err:
-            print(err)
+    downloader.download_attachments_from_dataframe(
+        uorg_2021_dataframe, attachment_column, attachments_join_field, 'full_file_path'
+    )
 
     #: Create an attachments dataframe by subsetting down to just the two fields and dropping any rows with null/empty attachments
     attachments_dataframe = uorg_2021_dataframe[[attachments_join_field, attachment_column]] \
                                                .copy().dropna(subset=attachment_column)
-    #: Create the full path by prepending the output directory using .apply and a lambda function
-    attachments_dataframe['full_file_path'] = attachments_dataframe[attachment_column].apply(
-        lambda filename: str(Path(out_dir, filename))
-    )
 
     #: General attachments dataframe layout:
     #:      | join_field | attachment_path_field |

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='ugrc-palletjack',
-    version='2.1.0',
+    version='2.2.0',
     license='MIT',
     description='Updating AGOL feature services with data from SFTP shares.',
     author='Jake Adams, UGRC',

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -198,9 +198,9 @@ class GoogleDriveDownloader:
         if not sharing_link:
             self._class_logger.debug('Row %s has no attachment info', join_id)
             return None
-        file_id = self._get_file_id_from_sharing_link(sharing_link)
-        self._class_logger.debug('Row %s: downloading file id %s', join_id, file_id)
+        self._class_logger.debug('Row %s: downloading file id %s', join_id, sharing_link)
         try:
+            file_id = self._get_file_id_from_sharing_link(sharing_link)
             response = self._get_http_response(file_id)
             filename = self._get_filename_from_response(response)
             out_file_path = self.out_dir / filename

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -198,9 +198,10 @@ class GoogleDriveDownloader:
         if not sharing_link:
             self._class_logger.debug('Row %s has no attachment info', join_id)
             return None
-        self._class_logger.debug('Row %s: downloading file id %s', join_id, sharing_link)
+        self._class_logger.debug('Row %s: downloading shared file %s', join_id, sharing_link)
         try:
             file_id = self._get_file_id_from_sharing_link(sharing_link)
+            self._class_logger.debug('Row %s: extracted file id %s', join_id, file_id)
             response = self._get_http_response(file_id)
             filename = self._get_filename_from_response(response)
             out_file_path = self.out_dir / filename

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -95,7 +95,7 @@ class GoogleDriveDownloader:
         self._class_logger.debug('Initializing GoogleDriveDownloader')
         self._class_logger.debug('Output directory: %s', out_dir)
         self.out_dir = Path(out_dir)
-        regex_pattern = 'https:\/\/drive.google.com\/file\/d\/(\S*)\/.*'  # pylint:disable=anomalous-backslash-in-string
+        regex_pattern = '(\/|=)([-\w]{25,})'  # pylint:disable=anomalous-backslash-in-string
         self._class_logger.debug('Regex pattern: %s', regex_pattern)
         self.regex = re.compile(regex_pattern)
 
@@ -178,7 +178,7 @@ class GoogleDriveDownloader:
         match = self.regex.search(sharing_link)
         if match:
             try:
-                return match.group(1)
+                return match.group(2)
             #: Not sure how this would happen (can't even figure out a test), but leaving in for safety.
             except IndexError as err:
                 raise IndexError(f'Regex could not extract the file id from sharing link {sharing_link}') from err

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -205,7 +205,7 @@ class GoogleDriveDownloader:
             out_file_path = self.out_dir / filename
             self._save_response_content(response, out_file_path)
             return out_file_path
-        except RuntimeError as err:
+        except Exception as err:
             self._class_logger.warning('Row %s: Couldn\'t download %s', join_id, sharing_link)
             self._class_logger.warning(err)
             return None
@@ -213,7 +213,7 @@ class GoogleDriveDownloader:
     def download_attachments_from_dataframe(self, dataframe, sharing_link_column, join_id_column, output_path_column):
         #: TODO: Write tests for this .apply call
         dataframe[output_path_column] = dataframe.apply(
-            lambda x: self.download_image_from_google_drive(x[sharing_link_column], x[join_id_column]), index=1
+            lambda x: self.download_image_from_google_drive(x[sharing_link_column], x[join_id_column]), axis=1
         )
         return dataframe
 

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -184,14 +184,15 @@ class GoogleDriveDownloader:
                 raise IndexError(f'Regex could not extract the file id from sharing link {sharing_link}') from err
         raise RuntimeError(f'Regex could not match sharing link {sharing_link}')
 
-    def download_image_from_google_drive(self, sharing_link, join_id):
+    def download_file_from_google_drive(self, sharing_link, join_id):
         """Download a publicly-shared image from Google Drive using it's sharing link
 
         Args:
             sharing_link (str): The publicly-shared link to the image.
+            join_id (str or int): The unique key for the row (used for reporting)
 
         Returns:
-            Path: Path of downloaded file
+            Path: Path of downloaded file or None if download fails/is not possible
         """
 
         if not sharing_link:
@@ -211,9 +212,20 @@ class GoogleDriveDownloader:
             return None
 
     def download_attachments_from_dataframe(self, dataframe, sharing_link_column, join_id_column, output_path_column):
-        #: TODO: Write tests for this .apply call
+        """Download the attachments linked in a dataframe column, creating a new column with the resulting path
+
+        Args:
+            dataframe (pd.DataFrame): Input dataframe with required columns
+            sharing_link_column (str): Column holding the Google sharing link
+            join_id_column (str): Column holding a unique key (for reporting purposes)
+            output_path_column (str): Column for the resulting path; will be added if it doesn't existing in the dataframe
+
+        Returns:
+            pd.DataFrame: Input dataframe with output path info
+        """
+
         dataframe[output_path_column] = dataframe.apply(
-            lambda x: self.download_image_from_google_drive(x[sharing_link_column], x[join_id_column]), axis=1
+            lambda x: self.download_file_from_google_drive(x[sharing_link_column], x[join_id_column]), axis=1
         )
         return dataframe
 

--- a/src/palletjack/loaders.py
+++ b/src/palletjack/loaders.py
@@ -212,6 +212,25 @@ class GoogleDriveDownloader:
             self._class_logger.warning(err)
             return None
 
+    #: TODO: WIP
+    def download_file_from_google_drive_using_api(self, sharing_link, join_id):
+        if not sharing_link:
+            self._class_logger.debug('Row %s has no attachment info', join_id)
+            return None
+        self._class_logger.debug('Row %s: downloading shared file %s', join_id, sharing_link)
+        try:
+            file_id = self._get_file_id_from_sharing_link(sharing_link)
+            self._class_logger.debug('Row %s: extracted file id %s', join_id, file_id)
+            response = self._get_http_response(file_id)
+            filename = self._get_filename_from_response(response)
+            out_file_path = self.out_dir / filename
+            self._save_response_content(response, out_file_path)
+            return out_file_path
+        except Exception as err:
+            self._class_logger.warning('Row %s: Couldn\'t download %s', join_id, sharing_link)
+            self._class_logger.warning(err)
+            return None
+
     def download_attachments_from_dataframe(self, dataframe, sharing_link_column, join_id_column, output_path_column):
         """Download the attachments linked in a dataframe column, creating a new column with the resulting path
 

--- a/src/palletjack/testing.py
+++ b/src/palletjack/testing.py
@@ -1,0 +1,7 @@
+from palletjack import GoogleDriveDownloader
+
+out_dir = r'c:/temp/google_python_tests/'
+downloader = GoogleDriveDownloader(out_dir)
+outfile = downloader.download_file_from_google_drive(
+    'https://drive.google.com/file/d/1YtJhQMcPSd2udmxlKnxEyeeYtUkAkSxt/view?usp=sharing', 'test'
+)

--- a/src/palletjack/updaters.py
+++ b/src/palletjack/updaters.py
@@ -422,6 +422,33 @@ class FeatureServiceAttachmentsUpdater:
 
         return overwrites_count, adds_count
 
+    @staticmethod
+    def build_attachments_dataframe(input_dataframe, join_column, attachment_column, out_dir):
+        """Create an attachments dataframe by subsetting down to just the two fields and dropping any rows
+           with null/empty attachments
+
+        Args:
+            input_dataframe (pd.DataFrame): Input data containing at least the join and attachment filename columns
+            join_column (str): Unique key joining attachments to live data
+            attachment_column (str): Filename for each attachment
+            out_dir (str or Path): Output directory, will be used to build full path to attachment
+
+        Returns:
+            pd.DataFrame: Dataframe with join key, attachment name, and full attachment paths
+        """
+
+        #: Create an attachments dataframe by subsetting down to just the two fields and dropping any rows
+        #: with null/empty attachments
+
+        input_dataframe[attachment_column].replace('', np.nan, inplace=True)  #: pandas doesn't see empty strings as NAs
+        attachments_dataframe = input_dataframe[[join_column, attachment_column]] \
+                                            .copy().dropna(subset=[attachment_column])
+        #: Create the full path by prepending the output directory using .apply and a lambda function
+        attachments_dataframe['full_file_path'] = attachments_dataframe[attachment_column] \
+                                                    .apply(lambda filename: str(Path(out_dir, filename)))
+
+        return attachments_dataframe
+
 
 class FeatureServiceOverwriter:
     """Overwrites an AGOL Feature Service with data from a pandas DataFrame and a geometry source (Spatially-enabled

--- a/src/palletjack/updaters.py
+++ b/src/palletjack/updaters.py
@@ -405,7 +405,6 @@ class FeatureServiceAttachmentsUpdater:
                 self.failed_dict[target_oid] = ('update', filepath)
                 continue
 
-            self._class_logger.debug('%s', result)
             if not result['updateAttachmentResult']['success']:
                 warnings.warn(
                     f'Failed to update {old_name}, attachment ID {attachment_id}, on OID {target_oid} with {filepath}'
@@ -485,9 +484,6 @@ class FeatureServiceAttachmentsUpdater:
         Returns:
             pd.DataFrame: Dataframe with join key, attachment name, and full attachment paths
         """
-
-        #: Create an attachments dataframe by subsetting down to just the two fields and dropping any rows
-        #: with null/empty attachments
 
         input_dataframe[attachment_column].replace('', np.nan, inplace=True)  #: pandas doesn't see empty strings as NAs
         attachments_dataframe = input_dataframe[[join_column, attachment_column]] \

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -275,23 +275,32 @@ class TestGoogleDriveDownloader:
 
         tm.assert_frame_equal(downloaded_df, test_df)
 
-    def test_get_file_id_from_sharing_link_extracts_group(self, mocker):
+    def test_get_file_id_from_sharing_link_extracts_group_file_link(self, mocker):
 
         downloader = palletjack.GoogleDriveDownloader('foo')
-        test_link = 'https://drive.google.com/file/d/foo_bar_baz/view?usp=sharing'
+        test_link = 'https://drive.google.com/file/d/abcdefghijklm_opqrstuvwxy/view?usp=sharing'
 
         file_id = downloader._get_file_id_from_sharing_link(test_link)
 
-        assert file_id == 'foo_bar_baz'
+        assert file_id == 'abcdefghijklm_opqrstuvwxy'
 
-    def test_get_file_id_from_sharing_link_extracts_group_with_dashes_in_id(self, mocker):
+    def test_get_file_id_from_sharing_link_extracts_group_file_link_with_dashes(self, mocker):
 
         downloader = palletjack.GoogleDriveDownloader('foo')
-        test_link = 'https://drive.google.com/file/d/foo-bar-baz/view?usp=sharing'
+        test_link = 'https://drive.google.com/file/d/abcdefghijklm-opqrstuvwxy/view?usp=sharing'
 
         file_id = downloader._get_file_id_from_sharing_link(test_link)
 
-        assert file_id == 'foo-bar-baz'
+        assert file_id == 'abcdefghijklm-opqrstuvwxy'
+
+    def test_get_file_id_from_sharing_link_extracts_group_open_link(self, mocker):
+
+        downloader = palletjack.GoogleDriveDownloader('foo')
+        test_link = 'https://drive.google.com/open?id=abcdefghijklm_opqrstuvwxy'
+
+        file_id = downloader._get_file_id_from_sharing_link(test_link)
+
+        assert file_id == 'abcdefghijklm_opqrstuvwxy'
 
     def test_get_file_id_from_sharing_link_raises_error_on_failed_match(self, mocker):
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -194,7 +194,7 @@ class TestGoogleDriveDownloader:
 
         downloader = palletjack.GoogleDriveDownloader('/foo/bar')
 
-        downloader.download_image_from_google_drive('1234', 42)
+        downloader.download_file_from_google_drive('1234', 42)
 
         save_mock.assert_called_with('response', Path('/foo/bar/baz.png'))
 
@@ -207,7 +207,7 @@ class TestGoogleDriveDownloader:
 
         caplog.set_level(logging.DEBUG, logger='palletjack.loaders.GoogleDriveDownloader')
         caplog.clear()
-        result = downloader.download_image_from_google_drive('', 42)
+        result = downloader.download_file_from_google_drive('', 42)
 
         file_id_mock.assert_not_called()
         assert ['Row 42 has no attachment info'] == [rec.message for rec in caplog.records]
@@ -222,7 +222,7 @@ class TestGoogleDriveDownloader:
 
         caplog.set_level(logging.DEBUG, logger='palletjack.loaders.GoogleDriveDownloader')
         caplog.clear()
-        result = downloader.download_image_from_google_drive(None, 42)
+        result = downloader.download_file_from_google_drive(None, 42)
 
         file_id_mock.assert_not_called()
         assert ['Row 42 has no attachment info'] == [rec.message for rec in caplog.records]
@@ -243,7 +243,7 @@ class TestGoogleDriveDownloader:
 
         caplog.set_level(logging.DEBUG, logger='palletjack.loaders.GoogleDriveDownloader')
         caplog.clear()
-        result = downloader.download_image_from_google_drive('1234', 42)
+        result = downloader.download_file_from_google_drive('1234', 42)
 
         filename_mock.assert_not_called()
         assert [
@@ -256,7 +256,7 @@ class TestGoogleDriveDownloader:
     def test_download_attachments_from_dataframe_handles_multiple_rows(self, mocker):
 
         downloader_mock = mocker.Mock()
-        downloader_mock.download_image_from_google_drive.side_effect = ['foo/bar.png', 'baz/boo.png']
+        downloader_mock.download_file_from_google_drive.side_effect = ['foo/bar.png', 'baz/boo.png']
 
         sheet_dataframe = pd.DataFrame({
             'join_id': [1, 2],

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -247,7 +247,8 @@ class TestGoogleDriveDownloader:
 
         filename_mock.assert_not_called()
         assert [
-            'Row 42: downloading file id google_id',
+            'Row 42: downloading shared file 1234',
+            'Row 42: extracted file id google_id',
             'Row 42: Couldn\'t download 1234',
             'Boom',
         ] == [rec.message for rec in caplog.records]

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -1331,6 +1331,31 @@ class TestAttachments:
 
         tm.assert_frame_equal(current_attachments_df, test_df)
 
+    def test_check_attachment_dataframe_for_invalid_column_names_doesnt_raise_with_valid_names(self, mocker):
+        dataframe = pd.DataFrame(columns=['foo', 'bar'])
+        invalid_names = ['baz', 'boo']
+        palletjack.FeatureServiceAttachmentsUpdater._check_attachment_dataframe_for_invalid_column_names(
+            dataframe, invalid_names
+        )
+
+    def test_check_attachment_dataframe_for_invalid_column_names_raises_with_one_invalid(self, mocker):
+        dataframe = pd.DataFrame(columns=['foo', 'bar'])
+        invalid_names = ['foo', 'boo']
+        with pytest.raises(RuntimeError) as exc_info:
+            palletjack.FeatureServiceAttachmentsUpdater._check_attachment_dataframe_for_invalid_column_names(
+                dataframe, invalid_names
+            )
+        assert exc_info.value.args[0] == 'Attachment dataframe contains the following invalid names: [\'foo\']'
+
+    def test_check_attachment_dataframe_for_invalid_column_names_raises_with_all_invalid(self, mocker):
+        dataframe = pd.DataFrame(columns=['foo', 'bar'])
+        invalid_names = ['foo', 'bar']
+        with pytest.raises(RuntimeError) as exc_info:
+            palletjack.FeatureServiceAttachmentsUpdater._check_attachment_dataframe_for_invalid_column_names(
+                dataframe, invalid_names
+            )
+        assert exc_info.value.args[0] == 'Attachment dataframe contains the following invalid names: [\'foo\', \'bar\']'
+
     def test_add_attachments_by_oid_adds_and_doesnt_warn(self, mocker):
         action_df = pd.DataFrame({
             'OBJECTID': [1, 2],

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -784,6 +784,70 @@ class TestFeatureServiceInlineUpdaterResultParsing:
         }
 
 
+class TestFeatureServiceInlineUpdaterFieldValidation:
+
+    def test_validate_working_fields_in_live_and_new_dataframes_doesnt_raise_when_matching(self, mocker):
+        live_df = pd.DataFrame(columns=['field1', 'field2', 'field3'])
+        new_df = pd.DataFrame(columns=['field1', 'field2', 'field3'])
+        fields = ['field1', 'field2', 'field3']
+
+        updater_mock = mocker.Mock()
+        updater_mock.new_dataframe = new_df
+
+        #: This shouldn't raise an exception and so the test should pass
+        palletjack.FeatureServiceInlineUpdater._validate_working_fields_in_live_and_new_dataframes(
+            updater_mock, live_df, fields
+        )
+
+    def test_validate_working_fields_in_live_and_new_dataframes_raises_not_in_live(self, mocker):
+        live_df = pd.DataFrame(columns=['field1', 'field2'])
+        new_df = pd.DataFrame(columns=['field1', 'field2', 'field3'])
+        fields = ['field1', 'field2', 'field3']
+
+        updater_mock = mocker.Mock()
+        updater_mock.new_dataframe = new_df
+
+        with pytest.raises(RuntimeError) as exc_info:
+            palletjack.FeatureServiceInlineUpdater._validate_working_fields_in_live_and_new_dataframes(
+                updater_mock, live_df, fields
+            )
+        assert exc_info.value.args[
+            0
+        ] == 'Field mismatch between defined fields and either new or live data.\nFields not in live data: {\'field3\'}\nFields not in new data: set()'
+
+    def test_validate_working_fields_in_live_and_new_dataframes_raises_not_in_new(self, mocker):
+        live_df = pd.DataFrame(columns=['field1', 'field2', 'field3'])
+        new_df = pd.DataFrame(columns=['field1', 'field2'])
+        fields = ['field1', 'field2', 'field3']
+
+        updater_mock = mocker.Mock()
+        updater_mock.new_dataframe = new_df
+
+        with pytest.raises(RuntimeError) as exc_info:
+            palletjack.FeatureServiceInlineUpdater._validate_working_fields_in_live_and_new_dataframes(
+                updater_mock, live_df, fields
+            )
+        assert exc_info.value.args[
+            0
+        ] == 'Field mismatch between defined fields and either new or live data.\nFields not in live data: set()\nFields not in new data: {\'field3\'}'
+
+    def test_validate_working_fields_in_live_and_new_dataframes_raises_not_in_both(self, mocker):
+        live_df = pd.DataFrame(columns=['field1', 'field2'])
+        new_df = pd.DataFrame(columns=['field1', 'field2'])
+        fields = ['field1', 'field2', 'field3']
+
+        updater_mock = mocker.Mock()
+        updater_mock.new_dataframe = new_df
+
+        with pytest.raises(RuntimeError) as exc_info:
+            palletjack.FeatureServiceInlineUpdater._validate_working_fields_in_live_and_new_dataframes(
+                updater_mock, live_df, fields
+            )
+        assert exc_info.value.args[
+            0
+        ] == 'Field mismatch between defined fields and either new or live data.\nFields not in live data: {\'field3\'}\nFields not in new data: {\'field3\'}'
+
+
 class TestFeatureServiceInlineUpdaterIntegrated:
 
     def test_update_existing_features_in_hosted_feature_layer_no_matching_rows_returns_0(self, mocker, caplog):


### PR DESCRIPTION
Some changes I found while I wrote the UORG skid. These bring the use of that datapath more in line with the others (loader methods return a dataframe, updater methods consume a dataframe).