### PR TITLE
Feat: Overwrite (truncate and load) existing feature service

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "cSpell.words": [
     "AGRC",
     "Codecov",
+    "featurelayer",
+    "featureset",
     "fsupdater",
     "gsheet",
     "instafail",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='ugrc-palletjack',
-    version='2.2.0',
+    version='2.3.0',
     license='MIT',
     description='Updating AGOL feature services with data from SFTP shares.',
     author='Jake Adams, UGRC',

--- a/src/palletjack/updaters.py
+++ b/src/palletjack/updaters.py
@@ -55,7 +55,7 @@ class FeatureServiceInlineUpdater:
                         rows_updated += 1
                     except RuntimeError as error:
                         if 'The value type is incompatible with the field type' in str(error):
-                            raise ValueError('Field type mistmatch between dataframe and feature service') from error
+                            raise ValueError('Field type mismatch between dataframe and feature service') from error
         self._class_logger.info('%s rows updated', rows_updated)
 
         return rows_updated
@@ -500,9 +500,6 @@ class FeatureServiceOverwriter:
     """Overwrites an AGOL Feature Service with data from a spatially-enabled DataFrame.
     """
 
-    #: TODO: write tests, run integrated test
-    #: TODO: Make sure fields match, raise warning/error if not
-
     def __init__(self, gis):
         self.gis = gis
         self._class_logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
@@ -515,7 +512,7 @@ class FeatureServiceOverwriter:
             columns (iter): The new columns to be renamed
 
         Returns:
-            List<str>: The cleaned column names
+            Dict: Mapping {'original name': 'cleaned_name'}
         """
 
         rename_dict = {}

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -1824,3 +1824,48 @@ class TestFeatureServiceOverwriter:
         uploaded_features = overwriter.truncate_and_load_feature_service('abc', new_dataframe)
 
         assert uploaded_features == 42
+
+    def test_replace_nan_series_with_empty_strings_one_empty_one_non_empty_float(self, mocker):
+        df = pd.DataFrame({
+            'normal': [1., 2., 3.],
+            'empty': [np.nan, np.nan, np.nan],
+        })
+
+        fixed_df = palletjack.FeatureServiceOverwriter._replace_nan_series_with_empty_strings(mocker.Mock(), df)
+
+        test_df = pd.DataFrame({
+            'normal': [1., 2., 3.],
+            'empty': ['', '', ''],
+        })
+
+        tm.assert_frame_equal(fixed_df, test_df)
+
+    def test_replace_nan_series_with_empty_strings_other_series_has_nan(self, mocker):
+        df = pd.DataFrame({
+            'normal': [1., 2., np.nan],
+            'empty': [np.nan, np.nan, np.nan],
+        })
+
+        fixed_df = palletjack.FeatureServiceOverwriter._replace_nan_series_with_empty_strings(mocker.Mock(), df)
+
+        test_df = pd.DataFrame({
+            'normal': [1., 2., np.nan],
+            'empty': ['', '', ''],
+        })
+
+        tm.assert_frame_equal(fixed_df, test_df)
+
+    def test_replace_nan_series_with_empty_strings_other_series_is_empty_str(self, mocker):
+        df = pd.DataFrame({
+            'normal': ['', '', ''],
+            'empty': [np.nan, np.nan, np.nan],
+        })
+
+        fixed_df = palletjack.FeatureServiceOverwriter._replace_nan_series_with_empty_strings(mocker.Mock(), df)
+
+        test_df = pd.DataFrame({
+            'normal': ['', '', ''],
+            'empty': ['', '', ''],
+        })
+
+        tm.assert_frame_equal(fixed_df, test_df)

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -407,7 +407,7 @@ class TestFeatureServiceInlineUpdaterResultParsing:
 
             assert caplog.records[
                 0
-            ].message == 'The following 1 updates failed. As a result, all successfull updates should have been rolled back.'
+            ].message == 'The following 1 updates failed. As a result, all successful updates should have been rolled back.'
             assert caplog.records[0].levelname == 'WARNING'
 
             assert caplog.records[1].message == "Existing data: {'objectId': 2, 'data': 'bar'}"
@@ -526,7 +526,7 @@ class TestFeatureServiceInlineUpdaterResultParsing:
             assert caplog.records[2].levelname == 'DEBUG'
             assert caplog.records[
                 3
-            ].message == 'The following 1 updates failed. As a result, all successfull updates should have been rolled back.'
+            ].message == 'The following 1 updates failed. As a result, all successful updates should have been rolled back.'
             assert caplog.records[3].levelname == 'WARNING'
             assert caplog.records[4].message == "Existing data: {'objectId': 2, 'data': 'bar'}"
             assert caplog.records[4].levelname == 'WARNING'
@@ -1567,7 +1567,7 @@ class TestAttachments:
 
         count = updater._overwrite_attachments_by_oid(action_df, 'path')
         assert count == 1
-        assert 'AGOL error while overwritting oldname1 (attachment ID 11) on OID 1 with path1' in caplog.text
+        assert 'AGOL error while overwriting oldname1 (attachment ID 11) on OID 1 with path1' in caplog.text
         assert 'foo' in caplog.text
         assert updater.failed_dict == {1: ('update', 'path1')}
 

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -1710,6 +1710,23 @@ class TestFeatureServiceOverwriter:
         assert exc_info.value.args[
             0] == 'New dataset contains the following fields that are not present in the live dataset: {\'Baz\'}'
 
+    def test_check_fields_match_ignores_new_shape_field(self, mocker):
+        mock_fl = mocker.Mock()
+        mock_fl.properties = {
+            'fields': [
+                {
+                    'name': 'Foo'
+                },
+                {
+                    'name': 'Bar'
+                },
+            ]
+        }
+        df = pd.DataFrame(columns=['Foo', 'Bar', 'SHAPE'])
+        overwriter = palletjack.FeatureServiceOverwriter(mocker.Mock())
+
+        palletjack.FeatureServiceOverwriter._check_fields_match(overwriter, mock_fl, df)
+
     def test_check_fields_match_warns_on_missing_new_field(self, mocker, caplog):
         mock_fl = mocker.Mock()
         mock_fl.properties = {


### PR DESCRIPTION
Implements a full truncate and load of a layer within a feature service using data from a spatially-enabled dataframe. Figured out how to use `.append()` for hopefully more performant, reliable edits.