### PR TITLE
Geocode a dataframe using the Web API geocoder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
       "type": "python",
       "request": "test",
       "console": "integratedTerminal",
+      "justMyCode": true,
       "env": {
         "PYTEST_ADDOPTS": "--no-cov"
       }

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='ugrc-palletjack',
-    version='2.4.1',
+    version='2.5.0',
     license='MIT',
     description='Updating AGOL feature services with data from SFTP shares.',
     author='Jake Adams, UGRC',

--- a/src/palletjack/__init__.py
+++ b/src/palletjack/__init__.py
@@ -1,6 +1,7 @@
 """A library for updating AGOL feature services with data from SFTP sources
 """
 
+from . import transform
 from .loaders import GoogleDriveDownloader, GSheetLoader, SFTPLoader
 from .updaters import (
     ColorRampReclassifier, FeatureServiceAttachmentsUpdater, FeatureServiceInlineUpdater, FeatureServiceOverwriter

--- a/src/palletjack/transform.py
+++ b/src/palletjack/transform.py
@@ -1,0 +1,41 @@
+"""transform.py: Processes in the Transfomation step of ETL
+"""
+
+import pandas as pd
+from arcgis import GeoAccessor, GeoSeriesAccessor
+
+from . import utils
+
+
+class APIGeocoder:
+    """Geocode using the UGRC Web API Geocoder.
+
+    Instantiate an APIGeocoder object with an api key from developer.mapserv.utah.gov
+    """
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def geocode_dataframe(self, dataframe, street_col, zone_col, wkid):
+        """Geocode a pandas dataframe into a spatially-enabled dataframe
+
+        Addresses that don't meet the threshold for geocoding (score > 70) are returned as points at 0,0
+
+        Args:
+            dataframe (pd.DataFrame): Input data with separate columns for street address and zip or city
+            street_col (str): The column containing the street address
+            zone_col (str): The column containing either the zip code or the city name
+            wkid (int): The projection to return the x/y points in
+
+        Returns:
+            pd.DataFrame.spatial: Geocoded data as a spatially-enabled DataFrame
+        """
+        dataframe[['x', 'y']] = dataframe.apply(
+            utils.geocode_addr,
+            axis=1,
+            args=(street_col, zone_col, self.api_key),
+            spatialReference=str(wkid),
+            result_type='expand'
+        )
+        spatial_dataframe = pd.DataFrame.spatial.from_xy(dataframe, 'x', 'y', sr=int(wkid))
+        return spatial_dataframe

--- a/src/palletjack/transform.py
+++ b/src/palletjack/transform.py
@@ -16,7 +16,7 @@ class APIGeocoder:
     def __init__(self, api_key):
         self.api_key = api_key
 
-    def geocode_dataframe(self, dataframe, street_col, zone_col, wkid):
+    def geocode_dataframe(self, dataframe, street_col, zone_col, wkid, **api_args):
         """Geocode a pandas dataframe into a spatially-enabled dataframe
 
         Addresses that don't meet the threshold for geocoding (score > 70) are returned as points at 0,0
@@ -35,7 +35,8 @@ class APIGeocoder:
             axis=1,
             args=(street_col, zone_col, self.api_key),
             spatialReference=str(wkid),
-            result_type='expand'
+            result_type='expand',
+            **api_args,
         )
         spatial_dataframe = pd.DataFrame.spatial.from_xy(dataframe, 'x', 'y', sr=int(wkid))
         return spatial_dataframe

--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -11,7 +11,9 @@ module_logger = logging.getLogger(__name__)
 def retry(worker_method, *args, **kwargs):
     """Allows you to retry a function/method three times to overcome network jitters
 
-    Retries worker_method three times (for a total of four tries, including the initial attempt), pausing 2^trycount seconds between each retry. Any arguments for worker_method can be passed in as additional parameters to _retry() following worker_method: _retry(foo_method, arg1, arg2, keyword_arg=3)
+    Retries worker_method three times (for a total of four tries, including the initial attempt), pausing 2^trycount
+    seconds between each retry. Any arguments for worker_method can be passed in as additional parameters to _retry()
+    following worker_method: _retry(foo_method, arg1, arg2, keyword_arg=3)
 
     Args:
         worker_method (callable): The name of the method to be retried (minus the calling parens)
@@ -178,7 +180,8 @@ def geocode_addr(row, street_col, zone_col, api_key, **api_args):
         street_col (str): The column/key containing the street address
         zone_col (str): The column/key containing the zip code or city
         api_key (str): API key obtained from developer.mapserv.utah.gov
-        **api_args (dict): Keyword arguments to be passed as parameters in the API GET call. The API key will be added to this dict.
+        **api_args (dict): Keyword arguments to be passed as parameters in the API GET call. The API key will be added
+        to this dict.
 
     Returns:
         List<int>: The address' x and y coordinates
@@ -186,12 +189,12 @@ def geocode_addr(row, street_col, zone_col, api_key, **api_args):
 
     url = f'https://api.mapserv.utah.gov/api/v1/geocode/{row[street_col]}/{row[zone_col]}'
     api_args['apiKey'] = api_key
-    r = requests.get(url, params=api_args)
+    get_response = retry(requests.get, url, params=api_args)
 
     #: If we don't get a good geocode, return Null Island points so that the conversion to spatial dataframe works
-    if r.status_code != 200:
+    if get_response.status_code != 200:
         return [0, 0]
-    response = r.json()
+    response = get_response.json()
     if response['status'] != 200:
         return [0, 0]
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+
+import palletjack
+
+
+class TestAPIGeocoder:
+
+    def test_geocode_dataframe_calls_with_right_args(self, mocker):
+        mocker.patch.object(palletjack.transform, 'utils', autospec=True)
+        palletjack.transform.utils.geocode_addr.side_effect = [
+            {
+                'x': 123,
+                'y': 456
+            },
+            {
+                'x': 789,
+                'y': 101
+            },
+        ]
+        mocker.patch.object(pd.DataFrame.spatial, 'from_xy')
+
+        geocoder = palletjack.transform.APIGeocoder('foo')
+
+        test_df = pd.DataFrame({
+            'street': ['4315 S 2700 W', '4501 S Constitution Blvd'],
+            'zip': ['84129', '84129'],
+        })
+
+        geocoder.geocode_dataframe(test_df, 'street', 'zip', 3857)
+
+        palletjack.transform.utils.geocode_addr.call_args.args == [
+            pd.array(['4501 S Constitution Blvd', '84129']), 'street', 'zip', 'foo'
+        ]
+        palletjack.transform.utils.geocode_addr.call_args.kwargs == {'spatialReference': '3857'}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -29,7 +29,36 @@ class TestAPIGeocoder:
 
         geocoder.geocode_dataframe(test_df, 'street', 'zip', 3857)
 
-        palletjack.transform.utils.geocode_addr.call_args.args == [
-            pd.array(['4501 S Constitution Blvd', '84129']), 'street', 'zip', 'foo'
+        assert list(palletjack.transform.utils.geocode_addr.call_args.args[0]) == ['4501 S Constitution Blvd', '84129']
+        assert palletjack.transform.utils.geocode_addr.call_args.args[1:] == ('street', 'zip', 'foo')
+        assert palletjack.transform.utils.geocode_addr.call_args.kwargs == {'spatialReference': '3857'}
+
+    def test_geocode_dataframe_passes_kwargs_through_to_util_method(self, mocker):
+        mocker.patch.object(palletjack.transform, 'utils', autospec=True)
+        palletjack.transform.utils.geocode_addr.side_effect = [
+            {
+                'x': 123,
+                'y': 456
+            },
+            {
+                'x': 789,
+                'y': 101
+            },
         ]
-        palletjack.transform.utils.geocode_addr.call_args.kwargs == {'spatialReference': '3857'}
+        mocker.patch.object(pd.DataFrame.spatial, 'from_xy')
+
+        geocoder = palletjack.transform.APIGeocoder('foo')
+
+        test_df = pd.DataFrame({
+            'street': ['4315 S 2700 W', '4501 S Constitution Blvd'],
+            'zip': ['84129', '84129'],
+        })
+
+        geocoder.geocode_dataframe(test_df, 'street', 'zip', 3857, acceptScore=80)
+
+        assert list(palletjack.transform.utils.geocode_addr.call_args.args[0]) == ['4501 S Constitution Blvd', '84129']
+        assert palletjack.transform.utils.geocode_addr.call_args.args[1:] == ('street', 'zip', 'foo')
+        assert palletjack.transform.utils.geocode_addr.call_args.kwargs == {
+            'spatialReference': '3857',
+            'acceptScore': 80
+        }


### PR DESCRIPTION
Adds an APIGeocoder class for geocoding dataframes. Also adds `transform.py` module in preparation for restructuring around the ETL steps (probably in v3.0.0)