### PR TITLE
fix: #18

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,11 +70,12 @@ Methods
 
 Updates the attributes of existing features in an AGOL Hosted Feature Service using either the `arcpy` or `arcgis` libraries. The `arcgis` library is required for interacting with AGOL.
 
-The initializer takes three arguments:
+The initializer has three required arguments and one optional argument:
 
 1. `gis`: An `arcgis.gis.GIS` object representing your AGOL organization.
 1. `dataframe`: A pandas dataframe containing the new data where each row is a separate record.
 1. `index_column`: The index column that is present in both the existing and new data for joining the datasets.
+1. `field_mapping`(optional): A dictionary of existing field names to new field names for matching the new data to the existing data in AGOL.
 
 Methods
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='ugrc-palletjack',
-    version='2.5.1',
+    version='2.6.0',
     license='MIT',
     description='Updating AGOL feature services with data from SFTP shares.',
     author='Jake Adams, UGRC',

--- a/src/palletjack/updaters.py
+++ b/src/palletjack/updaters.py
@@ -21,8 +21,10 @@ class FeatureServiceInlineUpdater:
     """Updates an AGOL Feature Service with data from a pandas DataFrame
     """
 
-    def __init__(self, gis, dataframe, index_column):
+    def __init__(self, gis, dataframe, index_column, field_mapping=None):
         self.gis = gis
+        if field_mapping:
+            dataframe = utils.rename_fields(dataframe, field_mapping)
         self.new_dataframe = dataframe.rename(columns=utils.rename_columns_for_agol(dataframe.columns))
         self.index_column = utils.rename_columns_for_agol([index_column])[index_column]
         try:

--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -141,6 +141,29 @@ def check_index_column_in_feature_layer(featurelayer, index_column):
         raise RuntimeError(f'Index column {index_column} not found in feature layer fields {featurelayer_fields}')
 
 
+def rename_fields(dataframe, field_mapping):
+    """Rename fields based on field_mapping
+
+    Args:
+        dataframe (pd.DataFrame): Dataframe with columns to be renamed
+        field_mapping (dict): Mapping of existing field names to new names
+
+    Raises:
+        ValueError: If an existing name from field_mapping is not found in dataframe.columns
+
+    Returns:
+        pd.DataFrame: Dataframe with renamed fields
+    """
+
+    for original_name in field_mapping.keys():
+        if original_name not in dataframe.columns:
+            raise ValueError(f'Field {original_name} not found in dataframe.')
+
+    renamed_df = dataframe.rename(columns=field_mapping)
+
+    return renamed_df
+
+
 #: This isn't used anymore... but it feels like a shame to lose it.
 def build_sql_in_list(series):
     """Generate a properly formatted list to be a target for a SQL 'IN' clause

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -634,3 +634,51 @@ class TestValidateAPIKey:
         assert check == 'Could not determine key validity; check your API key and/or network connection'
         assert palletjack.utils.requests.get.call_count == 4
         assert 'Random Error' in caplog.messages
+
+
+class TestFieldRenaming:
+
+    def test_rename_fields_renames_all_fields(self):
+        parcels_df = pd.DataFrame({
+            'account_no': [1, 2, 3],
+            'type': ['sf', 'mf', 'condo'],
+        })
+
+        field_mapping = {
+            'account_no': 'PARCEL_ID',
+            'type': 'class',
+        }
+
+        renamed_df = palletjack.utils.rename_fields(parcels_df, field_mapping)
+
+        assert list(renamed_df.columns) == ['PARCEL_ID', 'class']
+
+    def test_rename_fields_renames_some_fields(self):
+        parcels_df = pd.DataFrame({
+            'account_no': [1, 2, 3],
+            'class': ['sf', 'mf', 'condo'],
+        })
+
+        field_mapping = {
+            'account_no': 'PARCEL_ID',
+        }
+
+        renamed_df = palletjack.utils.rename_fields(parcels_df, field_mapping)
+
+        assert list(renamed_df.columns) == ['PARCEL_ID', 'class']
+
+    def test_rename_fields_raises_exception_for_missing_field(self):
+        parcels_df = pd.DataFrame({
+            'account_no': [1, 2, 3],
+            'type': ['sf', 'mf', 'condo'],
+        })
+
+        field_mapping = {
+            'account_no': 'PARCEL_ID',
+            'TYPE': 'class',
+        }
+
+        with pytest.raises(ValueError) as exception_info:
+            renamed_df = palletjack.utils.rename_fields(parcels_df, field_mapping)
+
+            assert 'Field TYPE not found in dataframe.' in str(exception_info)


### PR DESCRIPTION
Allow user to manually rename fields of new data to match existing data in AGOL for feature service overwriting. Closes #18 