### PR TITLE
feat: use Google API to download files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,19 @@ on: [push, pull_request]
 jobs:
   test:
     name: Setup and Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: 3.9
+
+    - name: Install libkrb5 for Kerberos on Linux
+        # if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt install -y libkrb5-dev
+        pip install requests-kerberos
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Report coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }}
         file: ./cov.xml
+        verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: pytest
 
     - name: Report coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        # token: ${{ secrets.CODECOV_TOKEN }}
         file: ./cov.xml

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![Build Status](https://github.com/agrc/palletjack/workflows/Build%20and%20Test/badge.svg)
 [![codecov](https://codecov.io/gh/agrc/palletjack/branch/main/graph/badge.svg)](https://codecov.io/gh/agrc/palletjack)
-<!-- 1. Navigate to [codecov.io](https://codecov.io/gh/agrc/python) and create a `CODECOV_TOKEN` [project secret](https://github.com/agrc/python/settings/secrets) -->
 
-A library of classes for automatically updating AGOL feature services with data from external sources. Client apps (often called 'skids') can reuse these classes for common use cases. These classes handle different parts of the Extract and Load steps in the ETL process. Tabular data is loaded into dataframes, which are then processed by the skid and passed to the updater classes that update the feature service.
+A library of classes for automatically updating AGOL feature services with data from external sources. Client apps (often called 'skids') can reuse these classes for common use cases. These classes handle different parts of the Extract and Load steps in the ETL process.
+
+`palletjack` works with pandas DataFrames (either regular for tabular data or Esri's spatially-enabled dataframes for spatial data). Most methods either return a dataframe or use a dataframe for their source data.
 
 See `docs/api.md` for documentation on the available classes and methods, logging, and errors.
 
@@ -24,7 +25,8 @@ Pallet jack: [forklift's](https://www.github.com/agrc/forklift) little brother.
 ## Usage
 
 1. `import palletjack`
-1. Instantiate objects as needed:
+1. Instantiate one or more of the classes as needed.
+1. Call the methods on your instantiated objects to perform the specific action desired.
 
    ```python
    loader = palletjack.SFTPLoader(secrets, download_dir)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agrc/palletjack
 
-<!-- ![Build Status](https://github.com/agrc/python/workflows/Build%20and%20Test/badge.svg)
-[![codecov](https://codecov.io/gh/agrc/python/branch/main/graph/badge.svg)](https://codecov.io/gh/agrc/python)
-1. Navigate to [codecov.io](https://codecov.io/gh/agrc/python) and create a `CODECOV_TOKEN` [project secret](https://github.com/agrc/python/settings/secrets) -->
+![Build Status](https://github.com/agrc/palletjack/workflows/Build%20and%20Test/badge.svg)
+[![codecov](https://codecov.io/gh/agrc/palletjack/branch/main/graph/badge.svg)](https://codecov.io/gh/agrc/palletjack)
+<!-- 1. Navigate to [codecov.io](https://codecov.io/gh/agrc/python) and create a `CODECOV_TOKEN` [project secret](https://github.com/agrc/python/settings/secrets) -->
 
 A library of classes for automatically updating AGOL feature services with data from external sources. Client apps (often called 'skids') can reuse these classes for common use cases. These classes handle different parts of the Extract and Load steps in the ETL process. Tabular data is loaded into dataframes, which are then processed by the skid and passed to the updater classes that update the feature service.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ The initializer takes five arguments:
 
 `GSheetLoader` allows you to import some or all of the worksheets within a Google Sheets document into a pandas dataframe.
 
-The initializer requires the path to a service account .json file that has access to the sheet in question. This account and file may need to be created by the GCP gurus.
+The initializer requires either the path to a service account .json file that has access to the sheet in question or a `google.auth.credentials.Credentials` object. The service account and file may need to be created by the GCP gurus. The Calling `google.auth.default()` in a Cloud Function environment will give you a tuple of the `Credentials` object of the current project and the project id. You can use this `Credentials` object to authorize pygsheets for the same account as the Cloud Function.
 
 #### Methods
 
@@ -57,7 +57,7 @@ The initializer requires the path to a service account .json file that has acces
 
 The initializer sets the output directory for saving the files. The `out_dir` attribute can be modified at any time to change this destination.
 
-This class has two similar sets of methods. The `*_using_api` methods authenticate to the Google API using a service account file and download using the API. If at all possible, use these methods to have the least likelihood of errors. They support publicly shared files along with files just shared to the service account.
+This class has two similar sets of methods. The `*_using_api` methods authenticate to the Google API using either a service account file or a `google.auth.credentials.Credentials` object and downloads using the API. If at all possible, use these methods to have the least likelihood of errors. They support publicly shared files along with files just shared to the service account.
 
 The other methods just use an anonymous HTTP request, which requires the files to be shared publicly. Google will block you from downloading after a certain amount of time/requests. A pause has been added to overcome this, but I've yet to find a good value for it.
 
@@ -65,8 +65,8 @@ The other methods just use an anonymous HTTP request, which requires the files t
 
 - `download_file_from_google_drive_using_api(self, gsheets_client, sharing_link, join_id)`
   - Download a file to the out_dir set on the instantiated object using the Google API. `gsheets_client` is the authenticated Client object from `pygsheets.authorize()`. `sharing_link` should be in the form `https://drive.google.com/file/d/big_long_id/etc`. `join_id` is used for logging purposes to identify which attachment is being worked on. Will log an error if the URL doesn't match this pattern or it can't extract the unique id from the sharing URL. Will also log an error if the header's Content-Type is text/html, which usually indicates the HTTP response was an error message instead of the file.
-- `download_attachments_from_dataframe_using_api(self, service_file, dataframe, sharing_link_column, join_id_column, output_path_column)`
-  - Calls `download_file_from_google_drive_using_api` for every row in `dataframe`, saving the full path of the resulting file in `output_path_column`. Uses `service_file` to authenticate to the Google API using `pygsheets.authorize()`
+- `download_attachments_from_dataframe_using_api(self, credentials, dataframe, sharing_link_column, join_id_column, output_path_column)`
+  - Calls `download_file_from_google_drive_using_api` for every row in `dataframe`, saving the full path of the resulting file in `output_path_column`. Uses `credentials` to authenticate to the Google API using `pygsheets.authorize()`
 - `download_file_from_google_drive(self, sharing_link, join_id, pause=0.)`
   - Download a file to the out_dir set on the instantiated object using an anonymous HTTP request. `sharing_link` should be in the form `https://drive.google.com/file/d/big_long_id/etc`. `join_id` is used for logging purposes to identify which attachment is being worked on. `pause` specifies a sleep in seconds before downloading to try to get around Google's blocking. Will log an error if the URL doesn't match this pattern or it can't extract the unique id from the sharing URL. Will also log an error if the header's Content-Type is text/html, which usually indicates the HTTP response was an error message instead of the file.
 - `download_attachments_from_dataframe(self, dataframe, sharing_link_column, join_id_column, output_path_column)`

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='ugrc-palletjack',
-    version='2.6.0',
+    version='2.6.2',
     license='MIT',
     description='Updating AGOL feature services with data from SFTP shares.',
     author='Jake Adams, UGRC',
@@ -34,7 +34,7 @@ setup(
     keywords=['gis'],
     install_requires=[
         'pysftp==0.2.9',
-        'arcgis==1.9.*',
+        'arcgis==2.0.*',
         'pygsheets==2.0.*',
     ],
     extras_require={

--- a/src/palletjack/updaters.py
+++ b/src/palletjack/updaters.py
@@ -611,6 +611,7 @@ class FeatureServiceOverwriter:
             target_featurelayer.append,
             upload_format='geojson',
             edits=geojson,
+            #:TODO figure out a way to preserve GUIDs?
             upsert=False,
             return_messages=True,
             rollback=True,

--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -14,8 +14,8 @@ def retry(worker_method, *args, **kwargs):
     """Allows you to retry a function/method three times to overcome network jitters
 
     Retries worker_method three times (for a total of four tries, including the initial attempt), pausing 2^trycount
-    seconds between each retry. Any arguments for worker_method can be passed in as additional parameters to _retry()
-    following worker_method: _retry(foo_method, arg1, arg2, keyword_arg=3)
+    seconds between each retry. Any arguments for worker_method can be passed in as additional parameters to retry()
+    following worker_method: retry(foo_method, arg1, arg2, keyword_arg=3)
 
     Args:
         worker_method (callable): The name of the method to be retried (minus the calling parens)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -254,6 +254,40 @@ class TestGoogleDriveDownloader:
         ] == [rec.message for rec in caplog.records]
         assert result is None
 
+    def test_download_file_from_google_drive_pauses_appropriately(self, mocker):
+        sleep_mock = mocker.patch.object(palletjack.loaders, 'sleep')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_file_id_from_sharing_link')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_http_response', return_value='response')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_filename_from_response', return_value='baz.png')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_save_response_content')
+
+        downloader = palletjack.GoogleDriveDownloader('/foo/bar')
+
+        downloader.download_file_from_google_drive('1234', 42, 1.5)
+
+        sleep_mock.assert_called_with(1.5)
+        sleep_mock.assert_called_once()
+
+    def test_download_attachments_from_dataframe_sleeps_specified_time(self, mocker):
+
+        sleep_mock = mocker.patch.object(palletjack.loaders, 'sleep')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_file_id_from_sharing_link')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_http_response', return_value='response')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_get_filename_from_response', return_value='baz.png')
+        mocker.patch.object(palletjack.GoogleDriveDownloader, '_save_response_content')
+
+        downloader = palletjack.GoogleDriveDownloader('/foo/bar')
+
+        sheet_dataframe = pd.DataFrame({
+            'join_id': [1],
+            'link': ['a'],
+        })
+
+        downloader.download_attachments_from_dataframe(sheet_dataframe, 'link', 'join_id', 'path')
+
+        sleep_mock.assert_called_with(5)
+        sleep_mock.assert_called_once()
+
     def test_download_attachments_from_dataframe_handles_multiple_rows(self, mocker):
 
         downloader_mock = mocker.Mock()

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -495,7 +495,7 @@ class TestGoogleDriveDownloaderAPI:
 
     def test_download_attachments_from_dataframe_using_api_handles_multiple_rows(self, mocker):
 
-        mocker.patch.object(palletjack.loaders, 'pygsheets')
+        mocker.patch.object(palletjack.utils, 'authorize_pygsheets')
 
         downloader_mock = mocker.Mock()
         downloader_mock.download_file_from_google_drive_using_api.side_effect = ['foo/bar.png', 'baz/boo.png']


### PR DESCRIPTION
Use the Google API to download files instead of anonymous HTTP requests (but still leave the old code... will probably deprecate in v3). 

Google will block your anonymous requests after a certain amount of time, so this provides a more reliable way to download files.