### PR TITLE
fix: remove shape fields from null fixer

### DIFF
--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -366,13 +366,16 @@ def fix_numeric_empty_strings(feature_set, feature_layer_fields):
         feature_set (arcgis.features.FeatureSet): Feature set to clean
         fields (Dict): fields from feature layer
     """
-    fix_field_names = []
-    for field in feature_layer_fields:
-        if field['type'] in ['esriFieldTypeDouble', 'esriFieldTypeInteger'] and field['nullable']:
-            fix_field_names.append(field['name'])
+
+    fields_to_fix = {
+        field['name']
+        for field in feature_layer_fields
+        if field['type'] in ['esriFieldTypeDouble', 'esriFieldTypeInteger'] and field['nullable']
+    }
+    fields_to_fix -= {'Shape__Length', 'Shape__Area'}
 
     for feature in feature_set.features:
-        for field_name in fix_field_names:
+        for field_name in fields_to_fix:
             if feature.attributes[field_name] == '':
                 feature.attributes[field_name] = None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -742,3 +742,67 @@ class TestEmptyStringsAsNulls:
 
         assert fixed_feature.attributes['a'] == ''
         assert fixed_feature.attributes['b'] is None
+
+    def test_fix_numeric_empty_strings_handles_both_missing_shape_info_fields(self):
+        FeatureSet = namedtuple('FeatureSet', ['features'])
+        Feature = namedtuple('Feature', ['attributes'])
+        feature_set = FeatureSet([Feature({
+            'a': 'foo',
+            'b': 'baz',
+        }), Feature({
+            'a': '',
+            'b': '',
+        })])
+        fields = [{
+            'name': 'a',
+            'type': 'esriFieldTypeInteger',
+            'nullable': False,
+        }, {
+            'name': 'b',
+            'type': 'esriFieldTypeInteger',
+            'nullable': True,
+        }, {
+            'name': 'Shape__Length',
+            'type': 'esriFieldTypeDouble',
+            'nullable': True,
+        }, {
+            'name': 'Shape__Area',
+            'type': 'esriFieldTypeDouble',
+            'nullable': True,
+        }]
+
+        fixed_feature_set = palletjack.utils.fix_numeric_empty_strings(feature_set, fields)
+        fixed_feature = fixed_feature_set.features[1]
+
+        assert fixed_feature.attributes['a'] == ''
+        assert fixed_feature.attributes['b'] is None
+
+    def test_fix_numeric_empty_strings_handles_single_missing_shape_info_field(self):
+        FeatureSet = namedtuple('FeatureSet', ['features'])
+        Feature = namedtuple('Feature', ['attributes'])
+        feature_set = FeatureSet([Feature({
+            'a': 'foo',
+            'b': 'baz',
+        }), Feature({
+            'a': '',
+            'b': '',
+        })])
+        fields = [{
+            'name': 'a',
+            'type': 'esriFieldTypeInteger',
+            'nullable': False,
+        }, {
+            'name': 'b',
+            'type': 'esriFieldTypeInteger',
+            'nullable': True,
+        }, {
+            'name': 'Shape__Length',
+            'type': 'esriFieldTypeDouble',
+            'nullable': True,
+        }]
+
+        fixed_feature_set = palletjack.utils.fix_numeric_empty_strings(feature_set, fields)
+        fixed_feature = fixed_feature_set.features[1]
+
+        assert fixed_feature.attributes['a'] == ''
+        assert fixed_feature.attributes['b'] is None


### PR DESCRIPTION
Removes Shape__Length and Shape_Area from fields to fix empty strings in numeric fields.