### PR TITLE
fix: use binary package for easier install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'pygsheets==2.0.*',
         'geopandas==0.12.*',
         'SQLAlchemy==1.4.*',
-        'psycopg2==2.9.*',
+        'psycopg2-binary==2.9.*',
         'numpy==1.23.*',  #: Pinned to fix "module 'numpy' has no attribute 'str'" error
     ],
     extras_require={


### PR DESCRIPTION
Sorry, I missed this before. The binary package makes the install much easier.