### PR TITLE
Thousands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 #: testing boilerplate
 _boilerplate.py
+_rest_testing.py
 
 #: Secrets file
 secrets.py

--- a/src/palletjack/__init__.py
+++ b/src/palletjack/__init__.py
@@ -2,6 +2,11 @@
 
 .. include:: ../../docs/README.md
 """
+import locale
 
 from . import extract, load, transform, utils
 from .errors import IntFieldAsFloatError, TimezoneAwareDatetimeError
+
+#: If the locale is not set explicitly, set it to the system default for text to number conversions
+if not locale.getlocale(locale.LC_NUMERIC)[0]:
+    locale.setlocale(locale.LC_NUMERIC, locale.getlocale())

--- a/src/palletjack/transform.py
+++ b/src/palletjack/transform.py
@@ -188,7 +188,7 @@ class DataCleaning:
         try:
             for field in fields_that_should_be_ints:
                 retyped[field] = DataCleaning._switch_series_to_numeric_dtype(retyped[field], 'Int64')
-        except ValueError as error:
+        except (TypeError, ValueError) as error:
             raise TypeError(
                 'Cannot convert one or more fields to nullable ints. Check for non-int/non-np.nan values.'
             ) from error
@@ -214,7 +214,7 @@ class DataCleaning:
         try:
             for field in fields_that_should_be_floats:
                 retyped[field] = DataCleaning._switch_series_to_numeric_dtype(retyped[field], 'float')
-        except ValueError as error:
+        except (TypeError, ValueError) as error:
             raise TypeError(
                 'Cannot convert one or more fields to floats. Check for non-float/non-null values.'
             ) from error

--- a/src/palletjack/transform.py
+++ b/src/palletjack/transform.py
@@ -183,9 +183,12 @@ class DataCleaning:
             pd.DataFrame: Input dataframe with columns converted to nullable Int64
         """
 
-        int_dict = {field: 'Int64' for field in fields_that_should_be_ints}
+        retyped = dataframe.copy()
         try:
-            retyped = dataframe.astype(int_dict)
+            for field in fields_that_should_be_ints:
+                retyped[field] = retyped[field].astype(str).str.replace(',', '')
+                retyped[field].replace('', None, inplace=True)
+                retyped[field] = retyped[field].astype('Int64')
         except TypeError as error:
             raise TypeError(
                 'Cannot convert one or more fields to nullable ints. Check for non-int/non-np.nan values.'
@@ -208,11 +211,12 @@ class DataCleaning:
             pd.DataFrame: Input dataframe with columns converted to float
         """
 
-        float_dict = {field: 'float' for field in fields_that_should_be_floats}
-        empty_string_dict = {field: {'': None} for field in fields_that_should_be_floats}
+        retyped = dataframe.copy()
         try:
-            no_empty_strings = dataframe.replace(empty_string_dict)
-            retyped = no_empty_strings.astype(float_dict)
+            for field in fields_that_should_be_floats:
+                retyped[field] = retyped[field].astype(str).str.replace(',', '')
+                retyped[field].replace('', None, inplace=True)
+                retyped[field] = retyped[field].astype(float)
         except TypeError as error:
             raise TypeError(
                 'Cannot convert one or more fields to floats. Check for non-float/non-null values.'

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -442,6 +442,18 @@ class TestNullableIntFixing:
 
         tm.assert_frame_equal(retyped_df, test_df)
 
+    def test_switch_to_nullable_int_raises_on_uncastable_text(self):
+        df = pd.DataFrame({
+            'a': [1, 2, np.nan],
+            'b': [1.1, 1.2, 'foo'],
+        })
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape('Cannot convert one or more fields to nullable ints. Check for non-int/non-np.nan values.')
+        ):
+            retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a', 'b'])
+
 
 class TestFloatFixing:
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -416,7 +416,7 @@ class TestNullableIntFixing:
 
         retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a'])
 
-        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
+        test_df = pd.DataFrame([1, 2, 3000], columns=['a'], dtype='Int64')
 
         tm.assert_frame_equal(retyped_df, test_df)
 
@@ -427,7 +427,7 @@ class TestNullableIntFixing:
 
         retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a'])
 
-        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
+        test_df = pd.DataFrame([1, 2, 3000], columns=['a'], dtype='Int64')
 
         tm.assert_frame_equal(retyped_df, test_df)
 
@@ -499,6 +499,39 @@ class TestFloatFixing:
         test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
 
         tm.assert_frame_equal(retyped_df, test_df)
+
+
+class TestSwitchSeriesToNumericDtype:
+
+    def test_switch_series_to_numeric_dtype_ints_to_Int64(self):
+        series1 = pd.Series([1, 2, 3, 4, 5])
+        test_series = pd.Series([1, 2, 3, 4, 5], dtype='Int64')
+        assert palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series1, 'Int64').equals(test_series)
+
+    def test_switch_series_to_numeric_dtype_str_to_float_with_thousands(self):
+        series2 = pd.Series(['1,000', '2,000', '3,000', '4,000', '5,000'])
+        test_series = pd.Series([1000.0, 2000.0, 3000.0, 4000.0, 5000.0])
+        assert palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series2, 'float').equals(test_series)
+
+    def test_switch_series_to_numeric_dtype_mixed_strings_ints_to_Int64(self):
+        series3 = pd.Series(['1,000', 2, '3,000', 4, '5,000'])
+        test_series = pd.Series([1000, 2, 3000, 4, 5000], dtype='Int64')
+        assert palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series3, 'Int64').equals(test_series)
+
+    def test_switch_series_to_numeric_dtype_mixed_strings_ints_to_float(self):
+        series3 = pd.Series(['1,000', 2, '3,000', 4, '5,000'])
+        test_series = pd.Series([1000.0, 2.0, 3000.0, 4.0, 5000.0])
+        assert palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series3, 'float').equals(test_series)
+
+    def test_switch_series_to_numeric_dtype_ints_with_nan_to_Int64(self):
+        series4 = pd.Series([1, 2, np.nan])
+        test_series = pd.Series([1, 2, pd.NA], dtype='Int64')
+        assert palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series4, 'Int64').equals(test_series)
+
+    def test_switch_series_to_numeric_dtype_raises_on_non_numeric(self):
+        series5 = pd.Series(['a', 'b', 'c', 'd', 'e'])
+        with pytest.raises(ValueError):
+            palletjack.transform.DataCleaning._switch_series_to_numeric_dtype(series5, 'float')
 
 
 class TestDatetimeSwitching:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -442,18 +442,6 @@ class TestNullableIntFixing:
 
         tm.assert_frame_equal(retyped_df, test_df)
 
-    def test_switch_to_nullable_int_raises_on_uncastable_text(self):
-        df = pd.DataFrame({
-            'a': [1, 2, np.nan],
-            'b': [1.1, 1.2, 'foo'],
-        })
-
-        with pytest.raises(
-            TypeError,
-            match=re.escape('Cannot convert one or more fields to nullable ints. Check for non-int/non-np.nan values.')
-        ):
-            retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a', 'b'])
-
 
 class TestFloatFixing:
 
@@ -511,6 +499,18 @@ class TestFloatFixing:
         test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
 
         tm.assert_frame_equal(retyped_df, test_df)
+
+    def test_switch_to_float_raises_on_uncastable_text(self):
+        df = pd.DataFrame({
+            'a': [1, 2, np.nan],
+            'b': [1.1, 1.2, 'foo'],
+        })
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape('Cannot convert one or more fields to floats. Check for non-float/non-null values.')
+        ):
+            retyped_df = palletjack.transform.DataCleaning.switch_to_float(df, ['a', 'b'])
 
 
 class TestSwitchSeriesToNumericDtype:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -409,6 +409,39 @@ class TestNullableIntFixing:
         ):
             retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a', 'b'])
 
+    def test_switch_to_nullable_int_comma_thousands_separator(self):
+        df = pd.DataFrame({
+            'a': ['1', '2', '3,000'],
+        })
+
+        retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a'])
+
+        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
+
+        tm.assert_frame_equal(retyped_df, test_df)
+
+    def test_switch_to_nullable_int_comma_thousands_separator_mixed_input_types(self):
+        df = pd.DataFrame({
+            'a': [1, '2', '3,000'],
+        })
+
+        retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a'])
+
+        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
+
+        tm.assert_frame_equal(retyped_df, test_df)
+
+    def test_switch_to_nullable_int_casts_string_field_with_empty_string(self):
+        df = pd.DataFrame({
+            'a': ['1', '2', ''],
+        })
+
+        retyped_df = palletjack.transform.DataCleaning.switch_to_nullable_int(df, ['a'])
+
+        test_df = pd.DataFrame([1, 2, pd.NA], columns=['a'], dtype='Int64')
+
+        tm.assert_frame_equal(retyped_df, test_df)
+
 
 class TestFloatFixing:
 
@@ -442,6 +475,28 @@ class TestFloatFixing:
         retyped_df = palletjack.transform.DataCleaning.switch_to_float(df, ['a'])
 
         test_df = pd.DataFrame([1., 2., np.nan], columns=['a'], dtype='float')
+
+        tm.assert_frame_equal(retyped_df, test_df)
+
+    def test_switch_to_float_comma_thousands_separator(self):
+        df = pd.DataFrame({
+            'a': ['1', '2', '3,000'],
+        })
+
+        retyped_df = palletjack.transform.DataCleaning.switch_to_float(df, ['a'])
+
+        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
+
+        tm.assert_frame_equal(retyped_df, test_df)
+
+    def test_switch_to_float_comma_thousands_separator_mixed_input_types(self):
+        df = pd.DataFrame({
+            'a': [1, 2., '3,000'],
+        })
+
+        retyped_df = palletjack.transform.DataCleaning.switch_to_float(df, ['a'])
+
+        test_df = pd.DataFrame([1., 2., 3000.], columns=['a'], dtype='float')
 
         tm.assert_frame_equal(retyped_df, test_df)
 


### PR DESCRIPTION
Better handling string values in the to_nullable_int and to_float transform methods.

Uses `locale`, but relies on client to set localization per [docs](https://docs.python.org/3/library/locale.html#background-details-hints-tips-and-caveats). However, most people probably don't think about this, so if `locale.LC_NUMERIC` isn't set, it sets it to the system default.

Closes #50 