### PR TITLE
fix: infinite recursion chunking a single-row dataframe

### DIFF
--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -836,6 +836,11 @@ class Chunking:
 
         df_length = len(dataframe)
 
+        if df_length == 1:
+            raise ValueError(
+                f'Dataframe chunk is only one row (index {dataframe.index[0]}), further chunking impossible'
+            )
+
         starts = range(0, df_length, chunk_size)
         ends = [start + chunk_size if start + chunk_size < df_length else df_length for start in starts]
         list_of_dataframes = [dataframe.iloc[start:end] for start, end in zip(starts, ends)]
@@ -908,10 +913,6 @@ class Chunking:
         for chunk_dataframe in list_of_dataframes:
             chunk_geojson_size = sys.getsizeof(chunk_dataframe.spatial.to_featureset().to_geojson.encode('utf-16'))
             if chunk_geojson_size > max_bytes:
-                if len(chunk_dataframe) == 1:
-                    raise ValueError(
-                        f'Dataframe row {chunk_dataframe.index[0]} is larger than {max_bytes} bytes, further chunking impossible'
-                    )
                 return_dataframes.extend(Chunking._recursive_dataframe_chunking(chunk_dataframe, max_bytes))
             else:
                 return_dataframes.append(chunk_dataframe)

--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -830,6 +830,9 @@ class Chunking:
             dataframe (pd.DataFrame): Input DataFrame
             chunk_size (int): The max number of rows for each sub dataframe
 
+        Raises:
+            ValueError: If the dataframe has only a single row and thus can't be chunked smaller
+
         Returns:
             list[pd.DataFrame]: A list of dataframes with at most chunk_size rows per dataframe
         """
@@ -891,14 +894,12 @@ class Chunking:
         the second chunk [4, 5, 6] turns out to be too large, so it gets divided into [4, 5] and [6]. The resulting
         list of chunks should be [1, 2, 3], [4, 5], [6], [7, 8, 9], [10].
 
-        Will raise an error if a single row is still larger than max_bytes.
+        The chunking process will raise an error if it tries to chunk a dataframe with only one row, which means a
+        single row is larger than max_bytes (usually caused by a large and complex geometry).
 
         Args:
             dataframe (pd.DataFrame.spatial): A spatially-enabled dataframe to divide
             max_bytes (int): The max utf-16 encoded geojson size for any one chunk
-
-        Raises:
-            ValueError: If a single row is larger than max_bytes and therefore cannot be chunked smaller
         """
 
         #: Calculate number of chunks needed and the guesstimate max number of rows to achieve that size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1767,6 +1767,25 @@ class TestDataFrameChunking:
         chunking_mock.assert_called_once()
         assert sys_mock.call_count == 2
 
+    def test_recursive_dataframe_chunking_raises_when_single_row_is_too_big(self, mocker):
+        #: First chunk triggers a recursive call, which returns a single row and should error out
+        df = pd.DataFrame(['a', 'b', 'c', 'd', 'e'], columns=['foo'])
+        mocker.patch('palletjack.utils.pd.DataFrame.spatial.to_featureset', return_value=mocker.Mock())
+        mocker.patch('palletjack.utils.Chunking._ceildiv')
+        sys_mock = mocker.patch('palletjack.utils.sys.getsizeof', side_effect=['foo', 10, 'foo', 5])
+        chunking_mock = mocker.patch(
+            'palletjack.utils.Chunking._chunk_dataframe',
+            side_effect=[
+                [df.iloc[:3], df.iloc[3:]],
+                [df.iloc[2:3]]  #: Second chunking returns a single row
+            ]
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            df_list = palletjack.utils.Chunking._recursive_dataframe_chunking(df, 4)
+
+        assert 'Dataframe row 2 is larger than 4 bytes, further chunking impossible' in str(exc_info.value)
+
     def test_build_upload_json_calls_null_string_fixer_appropriate_number_of_times(self, mocker):
 
         mock_df = mocker.Mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1779,6 +1779,7 @@ class TestDataFrameChunking:
         #: First chunk triggers a recursive call, which returns a single row and should error out
 
         max_bytes = 4
+        error_text = 'Dataframe chunk is only one row (index 2), further chunking impossible'
 
         df = pd.DataFrame(['a', 'b', 'c', 'd', 'e'], columns=['foo'])
         mocker.patch('palletjack.utils.pd.DataFrame.spatial.to_featureset', return_value=mocker.Mock())
@@ -1788,14 +1789,14 @@ class TestDataFrameChunking:
             'palletjack.utils.Chunking._chunk_dataframe',
             side_effect=[
                 [df.iloc[:3], df.iloc[3:]],
-                ValueError('Dataframe chunk is only one row (index 2), further chunking impossible'),
+                ValueError(error_text),
             ]
         )
 
         with pytest.raises(ValueError) as exc_info:
             df_list = palletjack.utils.Chunking._recursive_dataframe_chunking(df, max_bytes)
 
-        assert 'Dataframe chunk is only one row (index 2), further chunking impossible' in str(exc_info.value)
+        assert error_text in str(exc_info.value)
 
     def test_build_upload_json_calls_null_string_fixer_appropriate_number_of_times(self, mocker):
 


### PR DESCRIPTION
single rows with large, complex geometry are causing infinite recursion in the chunking method