### PR TITLE
Paginating salesforce querries

### DIFF
--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -1050,7 +1050,8 @@ class SalesforceRestLoader:
         """
         token = self._get_token()
 
-        response = requests.get(
+        response = utils.retry(
+            requests.get,
             f"{self.org_url}/{query_endpoint}",
             params=query_params,
             headers={

--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -986,12 +986,13 @@ class SalesforceRestLoader:
             return self.access_token
 
         form_data = {
-            "grant_type": "password",
+            "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
         }
 
         if self.sandbox:
+            form_data["grant_type"] = "password"
             form_data["username"] = self.username
             form_data["password"] = self.password
 


### PR DESCRIPTION
Salesforce REST queries are limited to 2000 results but include a url for continuing the request. This refactors out the actual HTTP call so that it can be used with either the initial query or the follow-on requests.