### PR TITLE
fix: remove date parsing from PostgresLoader

### DIFF
--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -543,9 +543,6 @@ class PostgresLoader:
         )
 
         spatial_dataframe = pd.DataFrame.spatial.from_geodataframe(dataframe, column_name=spatial_column)
-        for column in spatial_dataframe.select_dtypes(include=["datetime64[ns, UTC]"]):
-            self._class_logger.debug("Converting column `%s` to ISO string format", column)
-            spatial_dataframe[column] = spatial_dataframe[column].apply(pd.Timestamp.isoformat)
 
         self._class_logger.debug("Dataframe shape: %s", spatial_dataframe.shape)
         if len(spatial_dataframe.index) == 0:


### PR DESCRIPTION
This should be done via `transform.DataCleaning.switch_to_datetime` now and doing it via the loader was causing issues.