### PR TITLE
Switch to post for feature queries

### DIFF
--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -869,7 +869,7 @@ class ServiceLayer:
             unique_id_params["token"] = self.token
 
         self._class_logger.debug("OID range params: %s", unique_id_params)
-        response = requests.get(f"{self.layer_url}/query", params=unique_id_params, timeout=self.timeout)
+        response = requests.post(f"{self.layer_url}/query", data=unique_id_params, timeout=self.timeout)
 
         if response.status_code != 200:
             raise RuntimeError(f"Bad chunk response HTTP status code ({response.status_code})")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1008,7 +1008,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
+        post_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         mocker.patch("palletjack.extract.arcgis.features.FeatureSet")
         mocker.patch("palletjack.extract.len", return_value=5)
@@ -1017,7 +1017,7 @@ class Test_ServiceLayer:
 
         extract.ServiceLayer.get_unique_id_list_as_dataframe(class_mock, "OBJECTID", oid_list)
 
-        requests_mock.assert_called_once_with(
+        post_mock.assert_called_once_with(
             "foo.bar/query",
             data={"f": "json", "outFields": "*", "returnGeometry": "true", "where": "OBJECTID in (10,11,12,13,14)"},
             timeout=5,
@@ -1031,7 +1031,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 404
-        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
+        mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         oid_list = [10, 11, 12, 13, 14]
 
@@ -1046,7 +1046,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
+        mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         mocker.patch(
             "palletjack.extract.arcgis.features.FeatureSet.from_json",
@@ -1066,7 +1066,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
+        mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         featureset_mock = mocker.patch("palletjack.extract.arcgis.features.FeatureSet")
         featureset_mock.from_json.return_value.sdf.sort_values.return_value = pd.DataFrame(
@@ -1277,11 +1277,11 @@ class TestSalesForceLoader:
 
     def test_get_token_uses_client_credentials(self, loader, mocker):
         mocker.patch.object(loader, "_is_token_valid", return_value=False)
-        requests_mock = mocker.patch("palletjack.extract.requests.post")
+        post_mock = mocker.patch("palletjack.extract.requests.post")
 
         loader._get_token()
 
-        requests_mock.assert_called_once_with(
+        post_mock.assert_called_once_with(
             loader.access_token_url,
             data={
                 "grant_type": "client_credentials",
@@ -1294,14 +1294,14 @@ class TestSalesForceLoader:
 
     def test_get_token_uses_sandbox_credentials(self, loader, mocker):
         mocker.patch.object(loader, "_is_token_valid", return_value=False)
-        requests_mock = mocker.patch("palletjack.extract.requests.post")
+        post_mock = mocker.patch("palletjack.extract.requests.post")
         loader.sandbox = True
         loader.username = "user"
         loader.password = "pass"
 
         loader._get_token()
 
-        requests_mock.assert_called_once_with(
+        post_mock.assert_called_once_with(
             loader.access_token_url,
             data={
                 "grant_type": "password",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1008,7 +1008,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.get", return_value=response_mock)
+        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         mocker.patch("palletjack.extract.arcgis.features.FeatureSet")
         mocker.patch("palletjack.extract.len", return_value=5)
@@ -1019,7 +1019,7 @@ class Test_ServiceLayer:
 
         requests_mock.assert_called_once_with(
             "foo.bar/query",
-            params={"f": "json", "outFields": "*", "returnGeometry": "true", "where": "OBJECTID in (10,11,12,13,14)"},
+            data={"f": "json", "outFields": "*", "returnGeometry": "true", "where": "OBJECTID in (10,11,12,13,14)"},
             timeout=5,
         )
 
@@ -1031,7 +1031,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 404
-        requests_mock = mocker.patch("palletjack.extract.requests.get", return_value=response_mock)
+        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         oid_list = [10, 11, 12, 13, 14]
 
@@ -1046,7 +1046,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.get", return_value=response_mock)
+        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         mocker.patch(
             "palletjack.extract.arcgis.features.FeatureSet.from_json",
@@ -1066,7 +1066,7 @@ class Test_ServiceLayer:
 
         response_mock = mocker.Mock()
         response_mock.status_code = 200
-        requests_mock = mocker.patch("palletjack.extract.requests.get", return_value=response_mock)
+        requests_mock = mocker.patch("palletjack.extract.requests.post", return_value=response_mock)
 
         featureset_mock = mocker.patch("palletjack.extract.arcgis.features.FeatureSet")
         featureset_mock.from_json.return_value.sdf.sort_values.return_value = pd.DataFrame(


### PR DESCRIPTION
I was running into 413 http responses from the server. I assume that this is because the large where clauses were too long to be included as get request url parameters.