### PR TITLE
Support GeoDataFrame input to load methods via generalized df-to-gdf conversion method

### DIFF
--- a/src/palletjack/load.py
+++ b/src/palletjack/load.py
@@ -342,7 +342,8 @@ class ServiceUpdater:
         gdf = utils.convert_to_gdf(dataframe)
 
         try:
-            gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB")
+            #: promote_to_multi=True changes geometries to Multi* types if they aren't already
+            gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB", promote_to_multi=True)
         except pyogrio.errors.DataSourceError as error:
             raise ValueError(
                 f"Error writing layer to {gdb_path}. Verify {self.working_dir} exists and is writable."

--- a/src/palletjack/load.py
+++ b/src/palletjack/load.py
@@ -339,12 +339,7 @@ class ServiceUpdater:
         except TypeError as error:
             raise AttributeError(f"working_dir not specified on {self.__class__.__name__}") from error
 
-        try:
-            #: check if the dataframe is a spatially enabled dataframe
-            dataframe.spatial.geometry_type  # raises KeyError if this is a regular dataframe
-            gdf = utils.sedf_to_gdf(dataframe)
-        except KeyError:
-            gdf = gpd.GeoDataFrame(dataframe)
+        gdf = utils.convert_to_gdf(dataframe)
 
         try:
             gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB")

--- a/src/palletjack/utils.py
+++ b/src/palletjack/utils.py
@@ -378,12 +378,46 @@ def sedf_to_gdf(dataframe):
         GeoPandas.DataFrame: dataframe converted to GeoDataFrame
     """
 
+    warnings.warn(
+        "sedf_to_gdf is deprecated and will be removed in a future release. Use convert_to_gdf instead.",
+        DeprecationWarning,
+    )
+
     gdf = gpd.GeoDataFrame(dataframe, geometry=dataframe.spatial.name)
     try:
         gdf.set_crs(dataframe.spatial.sr.latestWkid, inplace=True)
     except AttributeError:
         gdf.set_crs(dataframe.spatial.sr.wkid, inplace=True)
 
+    return gdf
+
+
+def convert_to_gdf(dataframe):
+    """Given a dataframe, convert it to a GeoDataFrame. Non-spatially-enabled dataframes have no geometry, allowing them to be written as gdb tables.
+
+    Args:
+        dataframe (pd.DataFrame): Input dataframe, can be a regular dataframe, gdf, or sedf.
+
+    Returns:
+        gpd.GeoDataFrame: GeoDataFrame with or without geometry.
+    """
+
+    #: Already a gdf
+    if isinstance(dataframe, gpd.GeoDataFrame):
+        return dataframe
+
+    #: just a normal df, convert to gdf w/o geometry (allows us to write as table to gdb)
+    try:
+        dataframe.spatial.geometry_type  # raises KeyError if this is a regular dataframe
+    except KeyError:
+        return gpd.GeoDataFrame(dataframe, geometry=None)
+
+    #: spatially-enabled dataframe
+    gdf = gpd.GeoDataFrame(dataframe, geometry=dataframe.spatial.name)
+    try:
+        gdf.set_crs(dataframe.spatial.sr.latestWkid, inplace=True)
+    except AttributeError:
+        gdf.set_crs(dataframe.spatial.sr.wkid, inplace=True)
     return gdf
 
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1168,26 +1168,10 @@ class TestGDBStuff:
         updater_mock.working_dir = "/foo/bar"
         updater_mock.service = mocker.Mock()
 
-        mocker.patch("palletjack.utils.sedf_to_gdf")
+        mocker.patch("palletjack.utils.convert_to_gdf")
         shutil_mock = mocker.patch("palletjack.load.shutil")
 
         foo = load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, mocker.Mock())
-
-        shutil_mock.make_archive.assert_called_once_with(*expected_call_args, **expected_call_kwargs)
-
-    def test__save_to_gdb_and_zip_handles_tables(self, mocker):
-        expected_call_args = [Path("/foo/bar/upload.gdb"), "zip"]
-        expected_call_kwargs = {"root_dir": Path("/foo/bar"), "base_dir": "upload.gdb"}
-
-        updater_mock = mocker.Mock()
-        updater_mock.working_dir = "/foo/bar"
-        updater_mock.service = mocker.Mock()
-
-        mocker.patch("geopandas.GeoDataFrame")
-        shutil_mock = mocker.patch("palletjack.load.shutil")
-        dataframe = pd.DataFrame()
-
-        foo = load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, dataframe)
 
         shutil_mock.make_archive.assert_called_once_with(*expected_call_args, **expected_call_kwargs)
 
@@ -1199,7 +1183,7 @@ class TestGDBStuff:
         updater_mock.working_dir = "/foo/bar"
         updater_mock.service = mocker.Mock()
 
-        gdf_mock = mocker.patch("palletjack.utils.sedf_to_gdf").return_value
+        gdf_mock = mocker.patch("palletjack.utils.convert_to_gdf").return_value
         gdf_mock.to_file.side_effect = pyogrio.errors.DataSourceError
 
         with pytest.raises(ValueError, match=re.escape(expected_error)):
@@ -1209,7 +1193,7 @@ class TestGDBStuff:
         updater_mock = mocker.Mock()
         updater_mock.working_dir = "/foo/bar"
         updater_mock.service = mocker.Mock()
-        mocker.patch("palletjack.utils.sedf_to_gdf")
+        mocker.patch("palletjack.utils.convert_to_gdf")
         mocker.patch("palletjack.load.shutil.make_archive", side_effect=OSError("io error"))
 
         gdb_path = Path("/foo/bar/upload.gdb")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1873,3 +1873,60 @@ class TestSEDFtoGDF:
         palletjack.utils.sedf_to_gdf(mock_sedf)
 
         gpd_mock.assert_called_with(mock_sedf, geometry="FOOSHAPE")
+
+
+class TestConvertToGDF:
+    #: Tests created by copilot, checked and fixed by hand
+
+    def test_convert_to_gdf_returns_gdf_if_already_gdf(self, mocker):
+        gdf_mock = mocker.Mock(spec=palletjack.utils.gpd.GeoDataFrame)
+        result = palletjack.utils.convert_to_gdf(gdf_mock)
+        assert result is gdf_mock
+
+    def test_convert_to_gdf_returns_gdf_with_none_geometry_for_regular_df(self, mocker):
+        df_mock = mocker.Mock()
+        #: Simulate KeyError when accessing .spatial.geometry_type
+        type(df_mock).spatial = property(lambda self: (_ for _ in ()).throw(KeyError()))
+        gdf_mock = mocker.patch("palletjack.utils.gpd.GeoDataFrame")
+        #: since we're mocking gpd.GeoDataFrame, the isinstance check errors, so just make it return false
+        mocker.patch("palletjack.utils.isinstance", return_value=False)
+
+        result = palletjack.utils.convert_to_gdf(df_mock)
+
+        gdf_mock.assert_called_with(df_mock, geometry=None)
+        assert result == gdf_mock.return_value
+
+    def test_convert_to_gdf_handles_spatially_enabled_dataframe(self, mocker):
+        df_mock = mocker.Mock()
+        df_mock.spatial.geometry_type = "Point"
+        df_mock.spatial.name = "SHAPE"
+        df_mock.spatial.sr.latestWkid = 4326
+        gdf_mock = mocker.patch("palletjack.utils.gpd.GeoDataFrame").return_value
+        gdf_mock.set_crs = mocker.Mock()
+        #: since we're mocking gpd.GeoDataFrame, the isinstance check errors, so just make it return false
+        mocker.patch("palletjack.utils.isinstance", return_value=False)
+
+        result = palletjack.utils.convert_to_gdf(df_mock)
+
+        gdf_mock.set_crs.assert_called_with(4326, inplace=True)
+        assert result == gdf_mock
+
+    def test_convert_to_gdf_handles_spatially_enabled_dataframe_uses_wkid_instead_of_lakestwkid(self, mocker):
+        df_mock = mocker.Mock()
+        df_mock.spatial.geometry_type = "Point"
+        df_mock.spatial.name = "SHAPE"
+
+        #: spec out sr so that we get an AttributeError if we try to access latestWkid
+        sr_mock = mocker.Mock(spec="palletjack.utils.arcgis.geometry.SpatialReference")
+        sr_mock.wkid = 4326
+        df_mock.spatial.sr = sr_mock
+
+        gdf_mock = mocker.patch("palletjack.utils.gpd.GeoDataFrame").return_value
+        gdf_mock.set_crs = mocker.Mock()
+        #: since we're mocking gpd.GeoDataFrame, the isinstance check errors, so just make it return false
+        mocker.patch("palletjack.utils.isinstance", return_value=False)
+
+        result = palletjack.utils.convert_to_gdf(df_mock)
+
+        gdf_mock.set_crs.assert_called_with(4326, inplace=True)
+        assert result == gdf_mock


### PR DESCRIPTION
This generalizes/refactors the conversion to GeoDataFrame method to make it more reusable in other situations. It then converts _upload_data() to use this new method instead of in-line code, DRYing the code a little.

This allows us to pass an existing geodataframe into the load methods along with stock dataframes and spatially-enabled dataframes. Before this, you'd have to convert your gdf to a sedf, only to have palletjack convert it back to gdf to save and upload. 

Adds deprecation warning to old sedf_to_gdf() so that it gets pulled out next major version tickover.