### PR TITLE
hotfix: pin to older version of paramiko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "pygsheets==2.0.*",
         "pysftp==0.2.9",
         "SQLAlchemy>=1.4,<2.1",
+        "paramiko<4.0.0",
     ],
     extras_require={
         "tests": [

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         "pygsheets==2.0.*",
         "pysftp==0.2.9",
         "SQLAlchemy>=1.4,<2.1",
+        # Temporary pin to override pysftp's dependency resolution.
+        # TODO: Migrate away from pysftp to use paramiko directly. See https://github.com/agrc/palletjack/issues/123
         "paramiko<4.0.0",
     ],
     extras_require={


### PR DESCRIPTION
paramiko recently released 4.*, which removes some DSA key functionality. pysftp relies on this; however, pysftp hasn't been updated in years. Without this functionality, palletjack fails on import due to `ImportError: cannot import name 'DSSKey' from 'paramiko'`.

Short term fix is to pin to the older version of paramiko while re-writing palletjack to use paramiko directly, cutting out the stale pysftp project.

re: https://github.com/paramiko/paramiko/issues/2537, #142 