### PR TITLE
fix: don't promote points to multipoints

### DIFF
--- a/src/palletjack/load.py
+++ b/src/palletjack/load.py
@@ -341,8 +341,11 @@ class ServiceUpdater:
         gdf = utils.convert_to_gdf(dataframe)
 
         try:
-            #: promote_to_multi=True changes geometries to Multi* types if they aren't already
-            gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB", promote_to_multi=True)
+            #: promote non-point geometries to their Multi* equivalents
+            geom_types = gdf.geometry.geom_type.astype(str).str.lower().unique()
+            promote = not any("point" in gt for gt in geom_types)
+
+            gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB", promote_to_multi=promote)
         except pyogrio.errors.DataSourceError as error:
             raise ValueError(
                 f"Error writing layer to {gdb_path}. Verify {self.working_dir} exists and is writable."

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1215,6 +1215,63 @@ class TestGDBStuff:
 
         assert exc_info.value.__cause__.args[0] == expected_inner_error
 
+    def test__save_to_gdb_and_zip_promotes_to_polyline(self, mocker):
+        updater_mock = mocker.Mock()
+        updater_mock.working_dir = "/foo/bar"
+        mocker.patch("palletjack.load.shutil.make_archive")
+        gdf_mock = mocker.patch("palletjack.utils.convert_to_gdf").return_value
+        gdf_mock.geometry.geom_type = pd.Series(["LineString", "MultiLineString"])
+
+        gdb_path = Path("/foo/bar/upload.gdb")
+
+        load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, mocker.Mock())
+
+        assert gdf_mock.to_file.called_with(
+            gdb_path,
+            layer="upload",
+            engine="pyogrio",
+            driver="FileGDB",
+            promote_to_multi=True,
+        )
+
+    def test__save_to_gdb_and_zip_doesnt_promote_points(self, mocker):
+        updater_mock = mocker.Mock()
+        updater_mock.working_dir = "/foo/bar"
+        mocker.patch("palletjack.load.shutil.make_archive")
+        gdf_mock = mocker.patch("palletjack.utils.convert_to_gdf").return_value
+        gdf_mock.geometry.geom_type = pd.Series(["point", "point"])
+
+        gdb_path = Path("/foo/bar/upload.gdb")
+
+        load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, mocker.Mock())
+
+        assert gdf_mock.to_file.called_with(
+            gdb_path,
+            layer="upload",
+            engine="pyogrio",
+            driver="FileGDB",
+            promote_to_multi=False,
+        )
+
+    def test__save_to_gdb_and_zip_doesnt_promote_multipoints(self, mocker):
+        updater_mock = mocker.Mock()
+        updater_mock.working_dir = "/foo/bar"
+        mocker.patch("palletjack.load.shutil.make_archive")
+        gdf_mock = mocker.patch("palletjack.utils.convert_to_gdf").return_value
+        gdf_mock.geometry.geom_type = pd.Series(["mutlipoint", "mutlipoint"])
+
+        gdb_path = Path("/foo/bar/upload.gdb")
+
+        load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, mocker.Mock())
+
+        assert gdf_mock.to_file.called_with(
+            gdb_path,
+            layer="upload",
+            engine="pyogrio",
+            driver="FileGDB",
+            promote_to_multi=False,
+        )
+
     def test__upload_gdb_calls_add_default_name(self, mocker):
         gdb_path = Path("/foo/bar/upload.gdb")
         expected_call_kwargs = {


### PR DESCRIPTION
Promoting points to multipoints as part of the save to GDB step breaks feature services expecting just points. This occurred after the field checker did its thing, causing the data types to get out of sync.