### PR TITLE
feat: separate gdb upload from service update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pip-log.txt
 arc.dir
 .pytest_cache
 __pycache__
+.ruff_cache
 
 .env/
 .DS_Store


### PR DESCRIPTION
This moves the save to GDB, zip GDB, and upload GDB to AGOL steps out of and before the update service step. 

This means these operations are performed before the truncate of a truncate-and-load, which prevents the scenario where live data are truncated but a problem with the GDB operations causes the whole script to fail and leave the live service without any data.

There's also a little bit of type-hinting cleanup as well.