### PR TITLE
fix: handle promote_to_multi check failing on non-spatial gdfs

### DIFF
--- a/src/palletjack/load.py
+++ b/src/palletjack/load.py
@@ -364,11 +364,14 @@ class ServiceUpdater:
         gdf = utils.convert_to_gdf(dataframe)
 
         try:
-            #: promote non-point geometries to their Multi* equivalents
+            #: Figure out if we need to promote non-point geometries to their Multi* equivalents
             #: At this point, we assume that the field checker has verified homogenous geometry types
             geom_types = gdf.geometry.geom_type.astype(str).str.lower().unique()
             promote = not any("point" in gt for gt in geom_types)
+        except AttributeError:  #: A non-spatial gdf throws an AttributeError on gdf.geometry
+            promote = False
 
+        try:
             gdf.to_file(gdb_path, layer="upload", engine="pyogrio", driver="OpenFileGDB", promote_to_multi=promote)
         except pyogrio.errors.DataSourceError as error:
             raise ValueError(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1334,6 +1334,25 @@ class TestGDBStuff:
             promote_to_multi=False,
         )
 
+    def test__save_to_gdb_and_zip_does_not_promote_on_non_spatial_data(self, mocker):
+        updater_mock = mocker.Mock()
+        updater_mock.working_dir = "/foo/bar"
+        mocker.patch("palletjack.load.shutil.make_archive")
+        gdf_mock = mocker.patch("palletjack.utils.convert_to_gdf").return_value
+        gdf_mock.geometry.side_effect = AttributeError("No geometry column")
+
+        gdb_path = Path("/foo/bar/upload.gdb")
+
+        load.ServiceUpdater._save_to_gdb_and_zip(updater_mock, mocker.Mock())
+
+        assert gdf_mock.to_file.called_with(
+            gdb_path,
+            layer="upload",
+            engine="pyogrio",
+            driver="FileGDB",
+            promote_to_multi=False,
+        )
+
     def test__upload_gdb_calls_add_default_name(self, mocker):
         gdb_path = Path("/foo/bar/upload.gdb")
         expected_call_kwargs = {


### PR DESCRIPTION
Quick hotfix to handle attribute error in _save_to_gdb_and_zip()