### PR TITLE
feat(copilot): add wordpress loader to extract

### DIFF
--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -1272,7 +1272,7 @@ class WordpressRestLoader:
     Example::
 
         loader = WordpressRestLoader("https://example.com")
-        posts_df = loader.get_posts("posts", params={"categories": 5})
+        posts_df = loader.get_from_endpoint("posts", params={"categories": 5})
     """
 
     def __init__(self, base_url: str, timeout: int = 10, user_agent: str = "PalletjackWordpressLoader"):
@@ -1311,7 +1311,7 @@ class WordpressRestLoader:
         response.raise_for_status()
         return response
 
-    def get_posts(self, endpoint: str, params: dict | None = None, expand_acf: bool = False) -> pd.DataFrame:
+    def get_from_endpoint(self, endpoint: str, params: dict | None = None, expand_acf: bool = False) -> pd.DataFrame:
         """Fetch all items from an arbitrary WordPress REST endpoint.
 
         Pages through the results automatically using the ``X-WP-TotalPages``

--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -1272,7 +1272,7 @@ class WordpressRestLoader:
     Example::
 
         loader = WordpressRestLoader("https://example.com")
-        posts_df = loader.get_posts("wp/v2/posts", params={"categories": 5})
+        posts_df = loader.get_posts("posts", params={"categories": 5})
     """
 
     def __init__(self, base_url: str, timeout: int = 10, user_agent: str = "PalletjackWordpressLoader"):
@@ -1380,12 +1380,17 @@ class WordpressRestLoader:
                 values are dicts (as returned by the WordPress REST API).
 
         Raises:
-            ValueError: If the DataFrame does not contain an ``acf`` column.
+            ValueError: If the DataFrame is not empty and does not contain an
+                ``acf`` column.
 
         Returns:
             pd.DataFrame: A new DataFrame with the ``acf`` fields inlined.
         """
+        # Treat an empty DataFrame as a no-op so expand_acf can be used as a
+        # convenience flag without breaking on empty endpoint responses.
         if "acf" not in df.columns:
+            if df.empty:
+                return df
             raise ValueError("expand_acf is True but the DataFrame has no 'acf' column")
 
         acf_df = pd.json_normalize(df["acf"].where(df["acf"].notna(), other={}))

--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -1350,9 +1350,31 @@ class WordpressRestLoader:
             request_params["page"] = page
             response = self._get_page(url, request_params)
             page_data = response.json()
-            all_records.extend(page_data)
 
-            total_pages = int(response.headers.get("X-WP-TotalPages", 1))
+            if isinstance(page_data, list):
+                all_records.extend(page_data)
+            elif isinstance(page_data, dict):
+                # Some WordPress endpoints return a single object instead of a list.
+                # Treat that as a single record so we still produce a sensible DataFrame.
+                all_records.append(page_data)
+            else:
+                raise ValueError(
+                    f"Unexpected JSON type {type(page_data).__name__} from {url} on page {page}; "
+                    "expected list or dict."
+                )
+            total_pages_header = response.headers.get("X-WP-TotalPages")
+            if not total_pages_header:
+                total_pages = 1
+            else:
+                try:
+                    total_pages = int(total_pages_header)
+                except (TypeError, ValueError):
+                    self._class_logger.warning(
+                        "Invalid X-WP-TotalPages header %r from %s; defaulting to 1",
+                        total_pages_header,
+                        url,
+                    )
+                    total_pages = 1
             self._class_logger.debug("Fetched page %d of %d from %s", page, total_pages, url)
 
             if page >= total_pages:

--- a/src/palletjack/extract.py
+++ b/src/palletjack/extract.py
@@ -12,6 +12,7 @@ import re
 import time
 import warnings
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
@@ -30,6 +31,148 @@ from googleapiclient.http import MediaIoBaseDownload
 from palletjack import utils
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WordpressMediaSize:
+    """A single image size variant for a WordPress media item.
+
+    Corresponds to one entry in the ``media_details.sizes`` dict returned by
+    the WordPress REST API (e.g. ``thumbnail``, ``medium``, ``full``).
+    """
+
+    slug: str
+    file: str
+    width: int
+    height: int
+    mime_type: str
+    source_url: str
+
+    @classmethod
+    def from_dict(cls, slug: str, data: dict) -> "WordpressMediaSize":
+        """Build a WordpressMediaSize from a size dict returned by the WP REST API.
+
+        Args:
+            slug (str): The size key (e.g. ``"thumbnail"``).
+            data (dict): The size entry dict from ``media_details.sizes``.
+
+        Returns:
+            WordpressMediaSize: The populated data class.
+        """
+        return cls(
+            slug=slug,
+            file=data.get("file", ""),
+            width=data.get("width", 0),
+            height=data.get("height", 0),
+            mime_type=data.get("mime_type", ""),
+            source_url=data.get("source_url", ""),
+        )
+
+
+@dataclass
+class WordpressMediaDetails:
+    """Metadata about a WordPress media item's file dimensions and available sizes.
+
+    Corresponds to the ``media_details`` object in the WordPress REST API response.
+    """
+
+    width: int | None
+    height: int | None
+    file: str | None
+    filesize: int | None
+    sizes: dict[str, WordpressMediaSize] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WordpressMediaDetails":
+        """Build a WordpressMediaDetails from the ``media_details`` dict in a WP REST response.
+
+        Args:
+            data (dict): The ``media_details`` object from a WP REST media item response.
+
+        Returns:
+            WordpressMediaDetails: The populated data class.
+        """
+        sizes = {
+            slug: WordpressMediaSize.from_dict(slug, size_data) for slug, size_data in data.get("sizes", {}).items()
+        }
+        return cls(
+            width=data.get("width"),
+            height=data.get("height"),
+            file=data.get("file"),
+            filesize=data.get("filesize"),
+            sizes=sizes,
+        )
+
+
+@dataclass
+class WordpressMediaItem:
+    """A WordPress media library item as returned by the ``/wp/v2/media`` REST endpoint.
+
+    All fields match the top-level keys of the WP REST API media response.
+    Rendered fields (``guid``, ``title``, ``caption``, ``description``) are
+    automatically unwrapped from their ``{"rendered": "..."}`` wrapper.
+    """
+
+    id: int
+    date: str | None
+    date_gmt: str | None
+    modified: str | None
+    modified_gmt: str | None
+    guid: str | None
+    slug: str | None
+    status: str | None
+    link: str | None
+    title: str | None
+    author: int | None
+    alt_text: str | None
+    caption: str | None
+    description: str | None
+    media_type: str | None
+    mime_type: str | None
+    source_url: str | None
+    post: int | None
+    media_details: WordpressMediaDetails | None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WordpressMediaItem":
+        """Build a WordpressMediaItem from a WP REST API media response dict.
+
+        Automatically unwraps ``{"rendered": "..."}`` from ``guid``, ``title``,
+        ``caption``, and ``description``. Delegates ``media_details`` to
+        :class:`WordpressMediaDetails`.
+
+        Args:
+            data (dict): A single item from the WP REST ``/wp/v2/media`` endpoint.
+
+        Returns:
+            WordpressMediaItem: The populated data class.
+        """
+        raw_details = data.get("media_details")
+        return cls(
+            id=data.get("id"),
+            date=data.get("date"),
+            date_gmt=data.get("date_gmt"),
+            modified=data.get("modified"),
+            modified_gmt=data.get("modified_gmt"),
+            guid=data.get("guid", {}).get("rendered") if isinstance(data.get("guid"), dict) else data.get("guid"),
+            slug=data.get("slug"),
+            status=data.get("status"),
+            link=data.get("link"),
+            title=data.get("title", {}).get("rendered") if isinstance(data.get("title"), dict) else data.get("title"),
+            author=data.get("author"),
+            alt_text=data.get("alt_text"),
+            caption=data.get("caption", {}).get("rendered")
+            if isinstance(data.get("caption"), dict)
+            else data.get("caption"),
+            description=data.get("description", {}).get("rendered")
+            if isinstance(data.get("description"), dict)
+            else data.get("description"),
+            media_type=data.get("media_type"),
+            mime_type=data.get("mime_type"),
+            source_url=data.get("source_url"),
+            post=data.get("post"),
+            media_details=WordpressMediaDetails.from_dict(raw_details) if raw_details is not None else None,
+        )
 
 
 class GSheetLoader:
@@ -408,7 +551,7 @@ class SFTPLoader:
     @contextmanager
     def _sftp_connection(self):
         """Context manager for SFTP connections that ensures proper cleanup.
-        
+
         Yields:
             paramiko.SFTPClient: An active SFTP client
         """
@@ -430,9 +573,9 @@ class SFTPLoader:
 
         Args:
             remote_directory (str, optional): Absolute path to remote_directory on the SFTP server
-            overwrite_existing_files (bool, optional): If False, raise an error if a file already exists 
+            overwrite_existing_files (bool, optional): If False, raise an error if a file already exists
                 in download_dir. Defaults to True.
-        
+
         Raises:
             FileExistsError: If overwrite_existing_files is False and a file already exists
             FileNotFoundError: If the remote directory or file is not found
@@ -452,7 +595,7 @@ class SFTPLoader:
                 file_list = sftp.listdir(remote_directory)
             except FileNotFoundError as error:
                 raise FileNotFoundError(f"Directory `{remote_directory}` not found on SFTP server") from error
-            
+
             if not file_list:
                 raise ValueError("No files to download from remote directory")
 
@@ -460,11 +603,11 @@ class SFTPLoader:
         with self._sftp_connection() as sftp:
             for file_name in file_list:
                 outfile_path = self.download_dir / file_name
-                
+
                 # Check if file exists and overwrite is disabled
                 if not overwrite_existing_files and outfile_path.exists():
                     raise FileExistsError(f"File `{outfile_path}` already exists and overwrite_existing_files is False")
-                
+
                 try:
                     sftp.get(f"{remote_directory}{file_name}", outfile_path.as_posix())
                     downloaded_files.append(file_name)
@@ -489,7 +632,7 @@ class SFTPLoader:
 
         self._class_logger.info("Downloading %s from `%s` to `%s`", remote_file, self.host, self.download_dir)
         self._class_logger.debug("SFTP Username: %s", self.username)
-        
+
         with self._sftp_connection() as sftp:
             outfile_path = self.download_dir / Path(remote_file).name
             try:
@@ -1117,3 +1260,154 @@ class SalesforceRestLoader:
             raise ValueError(f"Error getting records from Salesforce {response.json()}") from error
 
         return response.json()
+
+
+class WordpressRestLoader:
+    """Loads data from a public WordPress REST API into pandas DataFrames.
+
+    Handles transparent pagination using the ``X-WP-TotalPages`` response header.
+    Designed for public (unauthenticated) WordPress sites; authentication is not
+    currently supported.
+
+    Example::
+
+        loader = WordpressRestLoader("https://example.com")
+        posts_df = loader.get_posts("wp/v2/posts", params={"categories": 5})
+    """
+
+    def __init__(self, base_url: str, timeout: int = 10, user_agent: str = "PalletjackWordpressLoader"):
+        """
+        Args:
+            base_url (str): The root URL of the WordPress site (e.g. ``"https://example.com"``).
+                Trailing slashes are stripped automatically.
+            timeout (int): HTTP request timeout in seconds. Defaults to 10.
+            user_agent (str): Value sent as the ``User-Agent`` request header.
+                Defaults to ``"PalletjackWordpressLoader"``.
+        """
+        self._class_logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.user_agent = user_agent
+
+    def _get_page(self, url: str, params: dict) -> requests.Response:
+        """Fetch a single page from the WordPress REST API.
+
+        Wraps the GET request in the standard retry mechanism and raises on
+        non-2xx HTTP responses.
+
+        Args:
+            url (str): The full URL to request.
+            params (dict): Query parameters to include in the request.
+
+        Raises:
+            requests.exceptions.HTTPError: If the server returns a non-2xx status code.
+
+        Returns:
+            requests.Response: The successful HTTP response.
+        """
+        response = utils.retry(
+            requests.get, url, params=params, headers={"User-Agent": self.user_agent}, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response
+
+    def get_posts(self, endpoint: str, params: dict | None = None, expand_acf: bool = False) -> pd.DataFrame:
+        """Fetch all items from an arbitrary WordPress REST endpoint.
+
+        Pages through the results automatically using the ``X-WP-TotalPages``
+        response header. Each page requests up to 100 items (``per_page=100``).
+        Caller-supplied ``params`` are merged in and take precedence over
+        defaults, except that ``page`` is always managed internally.
+
+        Args:
+            endpoint (str): The resource path beneath ``/wp-json/wp/v2/``
+                (e.g. ``"posts"`` or ``"/media"``).  A leading slash is
+                stripped automatically.
+            params (dict, optional): Extra query parameters forwarded to every
+                request (e.g. ``{"categories": 5, "status": "publish"}``).
+                Defaults to None.
+            expand_acf (bool): When ``True``, the ``acf`` dict on each record is
+                flattened into the top-level row. Field names that collide with an
+                existing column are prefixed with ``acf_``; others are added
+                without a prefix. The original ``acf`` column is dropped. Raises
+                ``ValueError`` if the response contains no ``acf`` column.
+                Defaults to ``False``.
+
+        Returns:
+            pd.DataFrame: All records from all pages combined into a single
+                DataFrame.  Returns an empty DataFrame if the endpoint returns
+                no items.
+        """
+        url = f"{self.base_url}/wp-json/wp/v2/{endpoint.lstrip('/')}"
+        request_params = {"per_page": 100, **(params or {})}
+
+        self._class_logger.debug("Fetching WordPress endpoint: %s", url)
+
+        all_records: list[dict] = []
+        page = 1
+
+        while True:
+            request_params["page"] = page
+            response = self._get_page(url, request_params)
+            page_data = response.json()
+            all_records.extend(page_data)
+
+            total_pages = int(response.headers.get("X-WP-TotalPages", 1))
+            self._class_logger.debug("Fetched page %d of %d from %s", page, total_pages, url)
+
+            if page >= total_pages:
+                break
+            page += 1
+
+        self._class_logger.info("Retrieved %d records from %s", len(all_records), url)
+        df = pd.DataFrame(all_records)
+
+        if expand_acf:
+            df = self._expand_acf(df)
+
+        return df
+
+    @staticmethod
+    def _expand_acf(df: pd.DataFrame) -> pd.DataFrame:
+        """Flatten the ``acf`` column of a DataFrame into individual columns.
+
+        Each ACF field is added directly to the DataFrame. If a field name
+        already exists as a column, it is prefixed with ``acf_`` to avoid
+        collision. The original ``acf`` column is dropped.
+
+        Args:
+            df (pd.DataFrame): DataFrame containing an ``acf`` column whose
+                values are dicts (as returned by the WordPress REST API).
+
+        Raises:
+            ValueError: If the DataFrame does not contain an ``acf`` column.
+
+        Returns:
+            pd.DataFrame: A new DataFrame with the ``acf`` fields inlined.
+        """
+        if "acf" not in df.columns:
+            raise ValueError("expand_acf is True but the DataFrame has no 'acf' column")
+
+        acf_df = pd.json_normalize(df["acf"].where(df["acf"].notna(), other={}))
+        existing = set(df.columns) - {"acf"}
+        acf_df.columns = [f"acf_{col}" if col in existing else col for col in acf_df.columns]
+        return pd.concat([df.drop(columns="acf"), acf_df], axis=1)
+
+    def get_media_item(self, media_id: int) -> WordpressMediaItem:
+        """Fetch a single media item by its WordPress ID.
+
+        Args:
+            media_id (int): The WordPress media item ID.
+
+        Raises:
+            requests.exceptions.HTTPError: If the server returns a non-2xx status
+                (e.g. 404 when the item does not exist).
+
+        Returns:
+            WordpressMediaItem: The media item populated from the API response.
+        """
+        url = f"{self.base_url}/wp-json/wp/v2/media/{media_id}"
+        self._class_logger.debug("Fetching WordPress media item: %s", url)
+        response = self._get_page(url, {})
+        self._class_logger.info("Retrieved media item %d from %s", media_id, url)
+        return WordpressMediaItem.from_dict(response.json())

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -534,7 +534,11 @@ class TestSFTPLoader:
         # Mock the context manager helper method
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = ["file_a", "file_b"]
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir")
 
@@ -551,14 +555,18 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance_1 = mocker.MagicMock(name="sftp1")
         sftp_instance_1.listdir.return_value = [Path("file_a"), Path("file_b")]
         sftp_instance_2 = mocker.MagicMock(name="sftp2")
-        
+
         # Mock the context manager helper method to return different instances
-        context_manager_1 = mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance_1), __exit__=mocker.Mock(return_value=False))
-        context_manager_2 = mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance_2), __exit__=mocker.Mock(return_value=False))
+        context_manager_1 = mocker.MagicMock(
+            __enter__=mocker.Mock(return_value=sftp_instance_1), __exit__=mocker.Mock(return_value=False)
+        )
+        context_manager_2 = mocker.MagicMock(
+            __enter__=mocker.Mock(return_value=sftp_instance_2), __exit__=mocker.Mock(return_value=False)
+        )
         sftploader_mock._sftp_connection = mocker.Mock(side_effect=[context_manager_1, context_manager_2])
 
         extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir/")
@@ -577,10 +585,14 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = ["file_a", "file_b"]
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir")
 
@@ -595,10 +607,14 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = ["file_a", "file_b"]
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir/")
 
@@ -610,10 +626,14 @@ class TestSFTPLoader:
 
         mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = []
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         with pytest.raises(ValueError, match="No files to download from remote directory"):
             extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir/")
@@ -628,10 +648,14 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.side_effect = FileNotFoundError("No such directory")
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         with pytest.raises(FileNotFoundError, match="Directory `remote/dir/` not found on SFTP server"):
             extract.SFTPLoader.download_sftp_folder_contents(sftploader_mock, "remote/dir/")
@@ -645,14 +669,18 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance_1 = mocker.MagicMock()
         sftp_instance_1.listdir.return_value = [Path("file_a"), Path("file_b")]
         sftp_instance_2 = mocker.MagicMock()
         sftp_instance_2.get.side_effect = FileNotFoundError("No such file")
-        
-        context_manager_1 = mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance_1), __exit__=mocker.Mock(return_value=False))
-        context_manager_2 = mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance_2), __exit__=mocker.Mock(return_value=False))
+
+        context_manager_1 = mocker.MagicMock(
+            __enter__=mocker.Mock(return_value=sftp_instance_1), __exit__=mocker.Mock(return_value=False)
+        )
+        context_manager_2 = mocker.MagicMock(
+            __enter__=mocker.Mock(return_value=sftp_instance_2), __exit__=mocker.Mock(return_value=False)
+        )
         sftploader_mock._sftp_connection = mocker.Mock(side_effect=[context_manager_1, context_manager_2])
 
         with pytest.raises(FileNotFoundError, match="File `remote/dir/file_a` not found on SFTP server"):
@@ -666,7 +694,11 @@ class TestSFTPLoader:
         sftploader_mock.download_dir = Path("local/dir")
 
         sftp_instance = mocker.MagicMock()
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         extract.SFTPLoader.download_sftp_single_file(sftploader_mock, "remote/file.txt")
 
@@ -682,9 +714,13 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         extract.SFTPLoader.download_sftp_single_file(sftploader_mock, "remote/file.txt")
 
@@ -699,10 +735,14 @@ class TestSFTPLoader:
 
         transport_mock = mocker.patch("palletjack.extract.paramiko.Transport", autospec=True)
         sftp_client_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient", autospec=True)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.get.side_effect = FileNotFoundError("No such file")
-        sftploader_mock._sftp_connection = mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)))
+        sftploader_mock._sftp_connection = mocker.MagicMock(
+            return_value=mocker.MagicMock(
+                __enter__=mocker.Mock(return_value=sftp_instance), __exit__=mocker.Mock(return_value=False)
+            )
+        )
 
         with pytest.raises(FileNotFoundError, match="File `remote/file.txt` not found on SFTP server"):
             extract.SFTPLoader.download_sftp_single_file(sftploader_mock, "remote/file.txt")
@@ -710,18 +750,18 @@ class TestSFTPLoader:
     def test_download_sftp_folder_contents_raises_on_file_exists_when_overwrite_disabled(self, mocker):
         """Test that FileExistsError is raised when overwrite_existing_files=False and file exists"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp/test"))
-        
+
         # Mock Path to return a path that exists
         mock_path = mocker.MagicMock(spec=Path)
         mock_path.exists.return_value = True
         mock_path.as_posix.return_value = "/tmp/test/existing_file.txt"
-        
+
         # Patch Path.__truediv__ to return our mock path
         mocker.patch.object(Path, "__truediv__", return_value=mock_path)
-        
+
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = ["existing_file.txt"]
-        
+
         transport_mock = mocker.MagicMock()
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
@@ -736,7 +776,7 @@ class TestSFTPLoader:
 
         sftp_instance = mocker.MagicMock()
         sftp_instance.listdir.return_value = ["file.txt"]
-        
+
         transport_mock = mocker.MagicMock()
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
@@ -749,22 +789,22 @@ class TestSFTPLoader:
     def test_sftp_connection_context_manager_success(self, mocker):
         """Test successful SFTP connection with proper cleanup"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp"))
-        
+
         transport_mock = mocker.MagicMock()
         sftp_mock = mocker.MagicMock()
-        
+
         transport_class_mock = mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
         sftp_class_mock.from_transport.return_value = sftp_mock
-        
+
         with loader._sftp_connection() as sftp:
             assert sftp == sftp_mock
-        
+
         # Verify connection was established
         transport_class_mock.assert_called_once_with(("test_host", 22))
         transport_mock.connect.assert_called_once_with(username="test_user", password="test_pass")
         sftp_class_mock.from_transport.assert_called_once_with(transport_mock)
-        
+
         # Verify cleanup happened
         sftp_mock.close.assert_called_once()
         transport_mock.close.assert_called_once()
@@ -772,16 +812,16 @@ class TestSFTPLoader:
     def test_sftp_connection_context_manager_connection_failure(self, mocker):
         """Test that cleanup happens when transport.connect fails"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp"))
-        
+
         transport_mock = mocker.MagicMock()
         transport_mock.connect.side_effect = Exception("Connection failed")
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
-        
+
         with pytest.raises(Exception, match="Connection failed"):
             with loader._sftp_connection() as sftp:
                 pass
-        
+
         # Verify cleanup happened even though connection failed
         # sftp was never created, so it shouldn't be closed
         transport_mock.close.assert_called_once()
@@ -789,52 +829,52 @@ class TestSFTPLoader:
     def test_sftp_connection_context_manager_auth_failure(self, mocker):
         """Test that cleanup happens when authentication fails"""
         loader = extract.SFTPLoader("test_host", "bad_user", "bad_pass", Path("/tmp"))
-        
+
         transport_mock = mocker.MagicMock()
         transport_mock.connect.side_effect = paramiko.AuthenticationException("Authentication failed")
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
-        
+
         with pytest.raises(paramiko.AuthenticationException, match="Authentication failed"):
             with loader._sftp_connection() as sftp:
                 pass
-        
+
         # Verify cleanup happened
         transport_mock.close.assert_called_once()
 
     def test_sftp_connection_context_manager_sftp_client_failure(self, mocker):
         """Test that cleanup happens when SFTPClient.from_transport fails"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp"))
-        
+
         transport_mock = mocker.MagicMock()
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
         sftp_class_mock.from_transport.side_effect = Exception("SFTP client creation failed")
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
-        
+
         with pytest.raises(Exception, match="SFTP client creation failed"):
             with loader._sftp_connection() as sftp:
                 pass
-        
+
         # Verify cleanup happened - transport should be closed even though sftp wasn't created
         transport_mock.close.assert_called_once()
 
     def test_sftp_connection_context_manager_exception_during_operation(self, mocker):
         """Test that cleanup happens when exception occurs during SFTP operations"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp"))
-        
+
         transport_mock = mocker.MagicMock()
         sftp_mock = mocker.MagicMock()
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
         sftp_class_mock.from_transport.return_value = sftp_mock
-        
+
         with pytest.raises(RuntimeError, match="Operation failed"):
             with loader._sftp_connection() as sftp:
                 # Simulate an exception during file operations
                 raise RuntimeError("Operation failed")
-        
+
         # Verify cleanup happened despite the exception
         sftp_mock.close.assert_called_once()
         transport_mock.close.assert_called_once()
@@ -842,60 +882,60 @@ class TestSFTPLoader:
     def test_download_sftp_folder_contents_with_real_context_manager(self, mocker):
         """Test download_sftp_folder_contents using real context manager (not mocked)"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp/test"))
-        
+
         test_files = ["file1.txt", "file2.txt"]
-        
+
         transport_mock = mocker.MagicMock()
         sftp_mock_1 = mocker.MagicMock()
         sftp_mock_1.listdir.return_value = test_files
         sftp_mock_2 = mocker.MagicMock()
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
         sftp_class_mock.from_transport.side_effect = [sftp_mock_1, sftp_mock_2]
-        
+
         result = loader.download_sftp_folder_contents("/remote/dir")
-        
+
         # Verify both connections were made
         assert transport_mock.connect.call_count == 2
         assert sftp_class_mock.from_transport.call_count == 2
-        
+
         # Verify both connections were cleaned up
         assert sftp_mock_1.close.call_count == 1
         assert sftp_mock_2.close.call_count == 1
         assert transport_mock.close.call_count == 2
-        
+
         # Verify operations
         sftp_mock_1.listdir.assert_called_once_with("/remote/dir/")
         sftp_mock_2.get.assert_any_call("/remote/dir/file1.txt", (Path("/tmp/test") / "file1.txt").as_posix())
         sftp_mock_2.get.assert_any_call("/remote/dir/file2.txt", (Path("/tmp/test") / "file2.txt").as_posix())
-        
+
         assert result == 2
 
     def test_download_sftp_single_file_with_real_context_manager(self, mocker):
         """Test download_sftp_single_file using real context manager (not mocked)"""
         loader = extract.SFTPLoader("test_host", "test_user", "test_pass", Path("/tmp/test"))
-        
+
         transport_mock = mocker.MagicMock()
         sftp_mock = mocker.MagicMock()
-        
+
         mocker.patch("palletjack.extract.paramiko.Transport", return_value=transport_mock)
         sftp_class_mock = mocker.patch("palletjack.extract.paramiko.SFTPClient")
         sftp_class_mock.from_transport.return_value = sftp_mock
-        
+
         result = loader.download_sftp_single_file("/remote/file.txt")
-        
+
         # Verify connection was made
         transport_mock.connect.assert_called_once_with(username="test_user", password="test_pass")
         sftp_class_mock.from_transport.assert_called_once_with(transport_mock)
-        
+
         # Verify cleanup happened
         sftp_mock.close.assert_called_once()
         transport_mock.close.assert_called_once()
-        
+
         # Verify operation - use as_posix() for cross-platform compatibility
         sftp_mock.get.assert_called_once_with("/remote/file.txt", (Path("/tmp/test") / "file.txt").as_posix())
-        
+
         assert result == Path("/tmp/test/file.txt")
 
     def test_read_csv_into_dataframe_with_column_names(self, mocker):
@@ -1702,3 +1742,251 @@ class TestSalesForceLoader:
 
         tm.assert_frame_equal(output_df, test_df)
         assert query_mock.call_count == 3
+
+
+WP_BASE_URL = "https://example.com"
+WP_ENDPOINT = "posts"
+WP_FULL_URL = f"{WP_BASE_URL}/wp-json/wp/v2/{WP_ENDPOINT}"
+
+
+class TestWordpressRestLoader:
+    @pytest.fixture
+    def loader(self):
+        return extract.WordpressRestLoader(WP_BASE_URL)
+
+    def test_get_posts_single_page(self, loader):
+        records = [{"id": 1, "title": "Hello"}, {"id": 2, "title": "World"}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
+            df = loader.get_posts(WP_ENDPOINT)
+
+        assert list(df.columns) == ["id", "title"]
+        assert len(df) == 2
+        assert df.iloc[0]["id"] == 1
+
+    def test_get_posts_multiple_pages(self, loader):
+        page1 = [{"id": 1}, {"id": 2}]
+        page2 = [{"id": 3}]
+        with requests_mock.Mocker() as m:
+            m.get(
+                WP_FULL_URL,
+                [
+                    {"json": page1, "headers": {"X-WP-TotalPages": "2"}},
+                    {"json": page2, "headers": {"X-WP-TotalPages": "2"}},
+                ],
+            )
+            df = loader.get_posts(WP_ENDPOINT)
+
+        assert len(df) == 3
+        assert list(df["id"]) == [1, 2, 3]
+
+    def test_get_posts_empty_response(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
+            df = loader.get_posts(WP_ENDPOINT)
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+
+    def test_get_posts_raises_on_http_error(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, status_code=404)
+            with pytest.raises(requests.exceptions.HTTPError):
+                loader.get_posts(WP_ENDPOINT)
+
+    def test_get_posts_passes_extra_params(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[{"id": 1}], headers={"X-WP-TotalPages": "1"})
+            loader.get_posts(WP_ENDPOINT, params={"categories": "5", "status": "publish"})
+
+        assert m.last_request.qs["categories"] == ["5"]
+        assert m.last_request.qs["status"] == ["publish"]
+
+    def test_expand_acf_flattens_acf_fields(self, loader):
+        records = [
+            {"id": 1, "title": "Post A", "acf": {"color": "red", "size": "large"}},
+            {"id": 2, "title": "Post B", "acf": {"color": "blue", "size": "small"}},
+        ]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
+            df = loader.get_posts(WP_ENDPOINT, expand_acf=True)
+
+        assert "acf" not in df.columns
+        assert "color" in df.columns
+        assert "size" in df.columns
+        assert list(df["color"]) == ["red", "blue"]
+
+    def test_expand_acf_prefixes_colliding_field_names(self, loader):
+        # "title" already exists as a top-level column — ACF field of same name gets prefixed
+        records = [{"id": 1, "title": "Top", "acf": {"title": "ACF Title", "color": "green"}}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
+            df = loader.get_posts(WP_ENDPOINT, expand_acf=True)
+
+        assert df.iloc[0]["title"] == "Top"
+        assert df.iloc[0]["acf_title"] == "ACF Title"
+        assert df.iloc[0]["color"] == "green"
+
+    def test_expand_acf_false_leaves_acf_column_intact(self, loader):
+        records = [{"id": 1, "acf": {"color": "red"}}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
+            df = loader.get_posts(WP_ENDPOINT, expand_acf=False)
+
+        assert "acf" in df.columns
+        assert "color" not in df.columns
+
+    def test_expand_acf_raises_if_no_acf_column(self, loader):
+        records = [{"id": 1, "title": "No ACF"}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
+            with pytest.raises(ValueError, match="no 'acf' column"):
+                loader.get_posts(WP_ENDPOINT, expand_acf=True)
+
+    def test_get_posts_endpoint_with_leading_slash(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
+            loader.get_posts(f"/{WP_ENDPOINT}")  # leading slash should be stripped
+
+        assert m.last_request.url.startswith(WP_FULL_URL)
+        assert "//" not in m.last_request.url.replace("https://", "")
+
+    def test_trailing_slash_stripped_from_base_url(self):
+        loader = extract.WordpressRestLoader("https://example.com/")
+        assert loader.base_url == "https://example.com"
+
+    def test_default_user_agent_sent_in_request(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
+            loader.get_posts(WP_ENDPOINT)
+
+        assert m.last_request.headers["User-Agent"] == "PalletjackWordpressLoader"
+
+    def test_custom_user_agent_sent_in_request(self):
+        loader = extract.WordpressRestLoader(WP_BASE_URL, user_agent="MyCustomAgent")
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
+            loader.get_posts(WP_ENDPOINT)
+
+        assert m.last_request.headers["User-Agent"] == "MyCustomAgent"
+
+    def test_get_media_item_returns_media_item(self, loader):
+        media_dict = {
+            "id": 99,
+            "date": "2024-03-01T12:00:00",
+            "date_gmt": None,
+            "modified": None,
+            "modified_gmt": None,
+            "guid": {"rendered": "https://example.com/wp-content/uploads/img.jpg"},
+            "slug": "img",
+            "status": "inherit",
+            "link": "https://example.com/?attachment_id=99",
+            "title": {"rendered": "Image"},
+            "author": 1,
+            "alt_text": "",
+            "caption": {"rendered": ""},
+            "description": {"rendered": ""},
+            "media_type": "image",
+            "mime_type": "image/jpeg",
+            "source_url": "https://example.com/wp-content/uploads/img.jpg",
+            "post": None,
+            "media_details": {"width": 800, "height": 600, "file": "img.jpg", "filesize": 51200, "sizes": {}},
+        }
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com/wp-json/wp/v2/media/99", json=media_dict)
+            item = loader.get_media_item(99)
+
+        assert isinstance(item, extract.WordpressMediaItem)
+        assert item.id == 99
+        assert item.guid == "https://example.com/wp-content/uploads/img.jpg"
+        assert item.media_details.width == 800
+
+    def test_get_media_item_raises_on_not_found(self, loader):
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com/wp-json/wp/v2/media/999", status_code=404)
+            with pytest.raises(requests.exceptions.HTTPError):
+                loader.get_media_item(999)
+
+    @pytest.fixture
+    def full_media_dict(self):
+        return {
+            "id": 42,
+            "date": "2024-01-15T10:00:00",
+            "date_gmt": "2024-01-15T17:00:00",
+            "modified": "2024-01-16T09:00:00",
+            "modified_gmt": "2024-01-16T16:00:00",
+            "guid": {"rendered": "https://example.com/wp-content/uploads/photo.jpg"},
+            "slug": "photo",
+            "status": "inherit",
+            "link": "https://example.com/?attachment_id=42",
+            "title": {"rendered": "Photo Title"},
+            "author": 1,
+            "alt_text": "A descriptive alt",
+            "caption": {"rendered": "<p>A caption</p>"},
+            "description": {"rendered": "<p>A description</p>"},
+            "media_type": "image",
+            "mime_type": "image/jpeg",
+            "source_url": "https://example.com/wp-content/uploads/photo.jpg",
+            "post": 7,
+            "media_details": {
+                "width": 1920,
+                "height": 1080,
+                "file": "2024/01/photo.jpg",
+                "filesize": 204800,
+                "sizes": {
+                    "thumbnail": {
+                        "file": "photo-150x150.jpg",
+                        "width": 150,
+                        "height": 150,
+                        "mime_type": "image/jpeg",
+                        "source_url": "https://example.com/wp-content/uploads/photo-150x150.jpg",
+                    },
+                    "full": {
+                        "file": "photo.jpg",
+                        "width": 1920,
+                        "height": 1080,
+                        "mime_type": "image/jpeg",
+                        "source_url": "https://example.com/wp-content/uploads/photo.jpg",
+                    },
+                },
+            },
+        }
+
+    def test_from_dict_full(self, full_media_dict):
+        item = extract.WordpressMediaItem.from_dict(full_media_dict)
+
+        assert item.id == 42
+        assert item.guid == "https://example.com/wp-content/uploads/photo.jpg"
+        assert item.title == "Photo Title"
+        assert item.caption == "<p>A caption</p>"
+        assert item.description == "<p>A description</p>"
+        assert item.post == 7
+        assert item.media_details is not None
+        assert item.media_details.width == 1920
+        assert item.media_details.filesize == 204800
+        assert "thumbnail" in item.media_details.sizes
+        assert item.media_details.sizes["thumbnail"].width == 150
+        assert item.media_details.sizes["thumbnail"].slug == "thumbnail"
+        assert item.media_details.sizes["full"].source_url == "https://example.com/wp-content/uploads/photo.jpg"
+
+    def test_from_dict_null_post(self, full_media_dict):
+        full_media_dict["post"] = None
+        item = extract.WordpressMediaItem.from_dict(full_media_dict)
+        assert item.post is None
+
+    def test_from_dict_empty_media_details(self, full_media_dict):
+        full_media_dict["media_details"] = {}
+        item = extract.WordpressMediaItem.from_dict(full_media_dict)
+        assert item.media_details is not None
+        assert item.media_details.width is None
+        assert item.media_details.sizes == {}
+
+    def test_from_dict_missing_media_details(self, full_media_dict):
+        del full_media_dict["media_details"]
+        item = extract.WordpressMediaItem.from_dict(full_media_dict)
+        assert item.media_details is None
+
+    def test_from_dict_missing_sizes_key(self, full_media_dict):
+        del full_media_dict["media_details"]["sizes"]
+        item = extract.WordpressMediaItem.from_dict(full_media_dict)
+        assert item.media_details.sizes == {}

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1758,7 +1758,7 @@ class TestWordpressRestLoader:
         records = [{"id": 1, "title": "Hello"}, {"id": 2, "title": "World"}]
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
-            df = loader.get_posts(WP_ENDPOINT)
+            df = loader.get_from_endpoint(WP_ENDPOINT)
 
         assert list(df.columns) == ["id", "title"]
         assert len(df) == 2
@@ -1775,7 +1775,7 @@ class TestWordpressRestLoader:
                     {"json": page2, "headers": {"X-WP-TotalPages": "2"}},
                 ],
             )
-            df = loader.get_posts(WP_ENDPOINT)
+            df = loader.get_from_endpoint(WP_ENDPOINT)
 
         assert len(df) == 3
         assert list(df["id"]) == [1, 2, 3]
@@ -1783,7 +1783,7 @@ class TestWordpressRestLoader:
     def test_get_posts_empty_response(self, loader):
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
-            df = loader.get_posts(WP_ENDPOINT)
+            df = loader.get_from_endpoint(WP_ENDPOINT)
 
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
@@ -1792,12 +1792,12 @@ class TestWordpressRestLoader:
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, status_code=404)
             with pytest.raises(requests.exceptions.HTTPError):
-                loader.get_posts(WP_ENDPOINT)
+                loader.get_from_endpoint(WP_ENDPOINT)
 
     def test_get_posts_passes_extra_params(self, loader):
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[{"id": 1}], headers={"X-WP-TotalPages": "1"})
-            loader.get_posts(WP_ENDPOINT, params={"categories": "5", "status": "publish"})
+            loader.get_from_endpoint(WP_ENDPOINT, params={"categories": "5", "status": "publish"})
 
         assert m.last_request.qs["categories"] == ["5"]
         assert m.last_request.qs["status"] == ["publish"]
@@ -1809,7 +1809,7 @@ class TestWordpressRestLoader:
         ]
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
-            df = loader.get_posts(WP_ENDPOINT, expand_acf=True)
+            df = loader.get_from_endpoint(WP_ENDPOINT, expand_acf=True)
 
         assert "acf" not in df.columns
         assert "color" in df.columns
@@ -1821,7 +1821,7 @@ class TestWordpressRestLoader:
         records = [{"id": 1, "title": "Top", "acf": {"title": "ACF Title", "color": "green"}}]
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
-            df = loader.get_posts(WP_ENDPOINT, expand_acf=True)
+            df = loader.get_from_endpoint(WP_ENDPOINT, expand_acf=True)
 
         assert df.iloc[0]["title"] == "Top"
         assert df.iloc[0]["acf_title"] == "ACF Title"
@@ -1831,7 +1831,7 @@ class TestWordpressRestLoader:
         records = [{"id": 1, "acf": {"color": "red"}}]
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
-            df = loader.get_posts(WP_ENDPOINT, expand_acf=False)
+            df = loader.get_from_endpoint(WP_ENDPOINT, expand_acf=False)
 
         assert "acf" in df.columns
         assert "color" not in df.columns
@@ -1841,12 +1841,12 @@ class TestWordpressRestLoader:
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "1"})
             with pytest.raises(ValueError, match="no 'acf' column"):
-                loader.get_posts(WP_ENDPOINT, expand_acf=True)
+                loader.get_from_endpoint(WP_ENDPOINT, expand_acf=True)
 
     def test_get_posts_endpoint_with_leading_slash(self, loader):
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
-            loader.get_posts(f"/{WP_ENDPOINT}")  # leading slash should be stripped
+            loader.get_from_endpoint(f"/{WP_ENDPOINT}")  # leading slash should be stripped
 
         assert m.last_request.url.startswith(WP_FULL_URL)
         assert "//" not in m.last_request.url.replace("https://", "")
@@ -1858,7 +1858,7 @@ class TestWordpressRestLoader:
     def test_default_user_agent_sent_in_request(self, loader):
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
-            loader.get_posts(WP_ENDPOINT)
+            loader.get_from_endpoint(WP_ENDPOINT)
 
         assert m.last_request.headers["User-Agent"] == "PalletjackWordpressLoader"
 
@@ -1866,7 +1866,7 @@ class TestWordpressRestLoader:
         loader = extract.WordpressRestLoader(WP_BASE_URL, user_agent="MyCustomAgent")
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
-            loader.get_posts(WP_ENDPOINT)
+            loader.get_from_endpoint(WP_ENDPOINT)
 
         assert m.last_request.headers["User-Agent"] == "MyCustomAgent"
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1843,6 +1843,59 @@ class TestWordpressRestLoader:
             with pytest.raises(ValueError, match="no 'acf' column"):
                 loader.get_from_endpoint(WP_ENDPOINT, expand_acf=True)
 
+    def test_expand_acf_no_op_on_empty_response(self, loader):
+        # expand_acf=True on an empty endpoint response should return an empty
+        # DataFrame without raising, because there are no rows to expand.
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})
+            df = loader.get_from_endpoint(WP_ENDPOINT, expand_acf=True)
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+
+    def test_get_from_endpoint_dict_response_treated_as_single_record(self, loader):
+        # Some WP endpoints return a single dict instead of a list (e.g. /wp/v2/settings).
+        single_record = {"option_a": "value_a", "option_b": "value_b"}
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=single_record, headers={"X-WP-TotalPages": "1"})
+            df = loader.get_from_endpoint(WP_ENDPOINT)
+
+        assert len(df) == 1
+        assert df.iloc[0]["option_a"] == "value_a"
+        assert df.iloc[0]["option_b"] == "value_b"
+
+    def test_get_from_endpoint_unexpected_json_type_raises(self, loader):
+        # If the endpoint returns something other than list or dict, a clear
+        # ValueError should be raised.
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json="unexpected string response", headers={"X-WP-TotalPages": "1"})
+            with pytest.raises(ValueError, match="Unexpected JSON type"):
+                loader.get_from_endpoint(WP_ENDPOINT)
+
+    def test_get_from_endpoint_missing_total_pages_header_defaults_to_1(self, loader):
+        # When X-WP-TotalPages is absent the loader should treat it as 1 page
+        # and make only a single request.
+        records = [{"id": 1}, {"id": 2}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records)  # no X-WP-TotalPages header
+            df = loader.get_from_endpoint(WP_ENDPOINT)
+
+        assert len(df) == 2
+        assert m.call_count == 1
+
+    def test_get_from_endpoint_malformed_total_pages_header_defaults_to_1(self, loader, caplog):
+        # When X-WP-TotalPages contains a non-numeric value the loader should
+        # log a warning and fall back to 1 page rather than raising.
+        records = [{"id": 1}]
+        with requests_mock.Mocker() as m:
+            m.get(WP_FULL_URL, json=records, headers={"X-WP-TotalPages": "not-a-number"})
+            with caplog.at_level(logging.WARNING):
+                df = loader.get_from_endpoint(WP_ENDPOINT)
+
+        assert len(df) == 1
+        assert m.call_count == 1
+        assert any("Invalid X-WP-TotalPages" in record.message for record in caplog.records)
+
     def test_get_posts_endpoint_with_leading_slash(self, loader):
         with requests_mock.Mocker() as m:
             m.get(WP_FULL_URL, json=[], headers={"X-WP-TotalPages": "1"})


### PR DESCRIPTION
Adding a wordpress loader to extract.py to load posts and/or media items from public Wordpress REST API endpoints.